### PR TITLE
Add support for og:image:alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ These values are placed in the conf.py of your sphinx project.
 * `ogp_image`
     * This is not required. Link to image to show.
 * `ogp_image_alt`
-    * This is not required. Alt text for image. Defaults to using `ogp_site_name` or the document's title as alt text,
-    if available. Set to `False` if you want to turn off alt text completely.
+    * This is not required. Alt text for image. Defaults to using `ogp_site_name` or the document's title as alt text, if available. Set to `False` if you want to turn off alt text completely.
 * `ogp_type`
     * This sets the ogp type attribute, for more information on the types available please take a look at https://ogp.me/#types. By default it is set to `website`, which should be fine for most use cases.
 * `ogp_custom_meta_tags`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ These values are placed in the conf.py of your sphinx project.
     * This is not required. Name of the site. This is displayed above the title.
 * `ogp_image`
     * This is not required. Link to image to show.
+* `ogp_image_alt`
+    * This is not required. Alt text for image. Defaults to using `ogp_site_name` as alt text, if available. Set to `False` if
+    you want to turn off alt text completely.
 * `ogp_type`
     * This sets the ogp type attribute, for more information on the types available please take a look at https://ogp.me/#types. By default it is set to `website`, which should be fine for most use cases.
 * `ogp_custom_meta_tags`

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ These values are placed in the conf.py of your sphinx project.
 * `ogp_image`
     * This is not required. Link to image to show.
 * `ogp_image_alt`
-    * This is not required. Alt text for image. Defaults to using `ogp_site_name` as alt text, if available. Set to `False` if
-    you want to turn off alt text completely.
+    * This is not required. Alt text for image. Defaults to using `ogp_site_name` or the document's title as alt text,
+    if available. Set to `False` if you want to turn off alt text completely.
 * `ogp_type`
     * This sets the ogp type attribute, for more information on the types available please take a look at https://ogp.me/#types. By default it is set to `website`, which should be fine for most use cases.
 * `ogp_custom_meta_tags`

--- a/sphinxext/opengraph.py
+++ b/sphinxext/opengraph.py
@@ -184,6 +184,15 @@ def get_tags(context: Dict[str, Any], doctree: nodes.document, config: Dict[str,
     if image_url:
         tags += make_tag("og:image", image_url)
 
+    # Add image alt text (either provided by config or from site_name)
+    ogp_image_alt = config["ogp_image_alt"]
+    if isinstance(ogp_image_alt, str):
+        tags += make_tag("og:image:alt", config["ogp_image_alt"])
+    elif config["ogp_image_alt"] and site_name:
+        tags += make_tag("og:image:alt", site_name)
+    elif config["ogp_image_alt"] and htp.text:
+        tags += make_tag("og:image:alt", htp.text)
+
     # custom tags
     tags += '\n'.join(config['ogp_custom_meta_tags'])
 
@@ -199,6 +208,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("ogp_site_url", None, "html")
     app.add_config_value("ogp_description_length", DEFAULT_DESCRIPTION_LENGTH, "html")
     app.add_config_value("ogp_image", None, "html")
+    app.add_config_value("ogp_image_alt", True, "html")
     app.add_config_value("ogp_type", "website", "html")
     app.add_config_value("ogp_site_name", None, "html")
     app.add_config_value("ogp_custom_meta_tags", [], "html")

--- a/sphinxext/opengraph.py
+++ b/sphinxext/opengraph.py
@@ -187,10 +187,10 @@ def get_tags(context: Dict[str, Any], doctree: nodes.document, config: Dict[str,
     # Add image alt text (either provided by config or from site_name)
     ogp_image_alt = config["ogp_image_alt"]
     if isinstance(ogp_image_alt, str):
-        tags += make_tag("og:image:alt", config["ogp_image_alt"])
-    elif config["ogp_image_alt"] and site_name:
+        tags += make_tag("og:image:alt", ogp_image_alt)
+    elif ogp_image_alt and site_name:
         tags += make_tag("og:image:alt", site_name)
-    elif config["ogp_image_alt"] and htp.text:
+    elif ogp_image_alt and htp.text:
         tags += make_tag("og:image:alt", htp.text)
 
     # custom tags
@@ -219,4 +219,3 @@ def setup(app: Sphinx) -> Dict[str, Any]:
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }
-

--- a/tests/roots/test-image/conf.py
+++ b/tests/roots/test-image/conf.py
@@ -5,5 +5,6 @@ exclude_patterns = ["_build"]
 
 html_theme = "basic"
 
+ogp_site_name = "Example's Docs!"
 ogp_site_url = "http://example.org/"
 ogp_image = "http://example.org/image.png"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -31,6 +31,11 @@ def test_image(og_meta_tags):
     assert get_tag_content(og_meta_tags, "image") == "http://example.org/image.png"
 
 
+@pytest.mark.sphinx("html", testroot="image")
+def test_image_alt(og_meta_tags):
+    assert get_tag_content(og_meta_tags, "image:alt") == "Example's Docs!"
+
+
 @pytest.mark.sphinx("html", testroot="type")
 def test_type(og_meta_tags):
     assert get_tag_content(og_meta_tags, "type") == "article"


### PR DESCRIPTION
This pull request adds support for og:image:alt (partially solves #10).

This is how the alt tag is generated:

* `ogp_image_alt` is a new option for conf.py. Any string provided with this option will be used as alt text
* If no string is provided, opengraph.py will try to automatically use `site_name` as alt text. If site_name is not available, `htp.text` will be used instead.
* The user also has the option to completely turn off alt text, by setting  `ogp_image_alt` to `False`.

This pull request also includes an additional test and an update to README.md.

According to [opg.me](https://ogp.me/#structured) any page that includes an og:image should also inclode an og:image:alt. This would not only increase compliance with opg but might also increase search engine visibility.