### PR TITLE
Use first image

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ These values are placed in the conf.py of your sphinx project.
     * This is not required. Link to image to show.
 * `ogp_image_alt`
     * This is not required. Alt text for image. Defaults to using `ogp_site_name` or the document's title as alt text, if available. Set to `False` if you want to turn off alt text completely.
+* `ogp_first_image`
+    * This is not required. Set to True to use each page's first image, if available. If set to True but no image is found, Sphinx will use `ogp_image` instead. 
 * `ogp_type`
     * This sets the ogp type attribute, for more information on the types available please take a look at https://ogp.me/#types. By default it is set to `website`, which should be fine for most use cases.
 * `ogp_custom_meta_tags`

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ These values are placed in the conf.py of your sphinx project.
     * This is not required. Link to image to show.
 * `ogp_image_alt`
     * This is not required. Alt text for image. Defaults to using `ogp_site_name` or the document's title as alt text, if available. Set to `False` if you want to turn off alt text completely.
-* `ogp_first_image`
-    * This is not required. Set to True to use each page's first image, if available. If set to True but no image is found, Sphinx will use `ogp_image` instead. 
+* `ogp_use_first_image`
+    * This is not required. Set to True to use each page's first image, if available. If set to True but no image is found, Sphinx will use `ogp_image` instead.
 * `ogp_type`
     * This sets the ogp type attribute, for more information on the types available please take a look at https://ogp.me/#types. By default it is set to `website`, which should be fine for most use cases.
 * `ogp_custom_meta_tags`

--- a/sphinxext/opengraph.py
+++ b/sphinxext/opengraph.py
@@ -210,7 +210,10 @@ def get_tags(
     og_image = None
     if first_image_available:
         for image_object in mcv.images:
-            if image_object["uri"][-4:].replace(".", "") in IMAGE_FILE_EXTENSIONS:
+            if (
+                image_object["uri"][-4:].replace(".", "").lower()
+                in IMAGE_FILE_EXTENSIONS
+            ):
                 og_image = image_object["uri"]
                 break
             else:

--- a/sphinxext/opengraph.py
+++ b/sphinxext/opengraph.py
@@ -211,7 +211,7 @@ def get_tags(
     if first_image_available:
         for image_object in mcv.images:
             if (
-                image_object["uri"][-4:].replace(".", "").lower()
+                image_object["uri"].split(".")[-1].lower()
                 in IMAGE_FILE_EXTENSIONS
             ):
                 og_image = image_object["uri"]

--- a/sphinxext/opengraph.py
+++ b/sphinxext/opengraph.py
@@ -7,6 +7,7 @@ import sphinx
 from sphinx.application import Sphinx
 
 DEFAULT_DESCRIPTION_LENGTH = 200
+IMAGE_FILE_EXTENSIONS = ["jpg", "jpeg", "png"]
 
 
 class HTMLTextParser(HTMLParser):
@@ -205,10 +206,18 @@ def get_tags(
     else:
         ogp_image_alt = False
 
-    # Get first image (if enabled in config and images detected)
+    # Detect first suitable image (if enabled in config and images detected)
+    og_image = None
     if first_image_available:
-        image = mcv.images[0]
-        tags += make_tag("og:image", urljoin(page_url, image["uri"]))
+        for image_object in mcv.images:
+            if image_object["uri"][-4:].replace(".", "") in IMAGE_FILE_EXTENSIONS:
+                og_image = image_object["uri"]
+                break
+            else:
+                og_image = None
+    # Use first image, if enabled (and suitable file type)
+    if og_image:
+        tags += make_tag("og:image", urljoin(page_url, og_image))
     # Get standard image (if enabled in config)
     elif image_url:
         tags += make_tag("og:image", image_url)

--- a/tests/roots/test-first-image/conf.py
+++ b/tests/roots/test-first-image/conf.py
@@ -9,4 +9,4 @@ ogp_site_name = "Example's Docs!"
 ogp_site_url = "http://example.org/"
 ogp_image = "http://example.org/image33.png"
 ogp_image_alt = "TEST"
-ogp_first_image = True
+ogp_use_first_image = True

--- a/tests/roots/test-first-image/conf.py
+++ b/tests/roots/test-first-image/conf.py
@@ -1,0 +1,12 @@
+extensions = ["sphinxext.opengraph"]
+
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+html_theme = "basic"
+
+ogp_site_name = "Example's Docs!"
+ogp_site_url = "http://example.org/"
+ogp_image = "http://example.org/image33.png"
+ogp_image_alt = "TEST"
+ogp_first_image = True

--- a/tests/roots/test-first-image/index.rst
+++ b/tests/roots/test-first-image/index.rst
@@ -1,0 +1,2 @@
+.. image:: http://example.org/image2.png
+   :alt: Test image alt text

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -39,6 +39,12 @@ def test_image_alt(og_meta_tags):
     assert get_tag_content(og_meta_tags, "image:alt") == "Example's Docs!"
 
 
+@pytest.mark.sphinx("html", testroot="first-image")
+def test_first_image(og_meta_tags):
+    assert get_tag_content(og_meta_tags, "image") == "http://example.org/image2.png"
+    assert get_tag_content(og_meta_tags, "image:alt") == "Test image alt text"
+
+
 @pytest.mark.sphinx("html", testroot="type")
 def test_type(og_meta_tags):
     assert get_tag_content(og_meta_tags, "type") == "article"


### PR DESCRIPTION
This pull request gives users the option to use the first image of each page for the page's `og:image` tag. 

If the new config-option `ogp_first_image` is set to `True`, sphinxext-opengraph will automatically scan each document's nodes for images. sphinxext-opengraph will then use the first image on the page for the `og:image` tag (if an image is present).

This is a feature I have been using in my own custom og-extension. When you share a news article on Facebook, for example, Facebook will usually display an image from the article itself, not a generic image from the news organization. So from a user's perspective, if I have an image on a page I am sharing, I'd expect `og:image` to be an image from that specific page, not just a generic image that would be the same for all the pages on this website.

ogp_first_image works well with the other image options sphinxext-opengraph already has. I have automated the behavior as much as possible and have tested various combinations locally. Some examples:

* Example 1: In the config, `ogp_first_image` is enabled, and an image is provided with `og:image`. Sphinx will use the first image for each sub-page that has an image - all pages that do not have images will use the image supplied by `og:image`.
*  Example 2: In the config, `ogp_first_image` is enabled, but no image is provided with `og:image`. Sphinx will use the first image for each sub-page that has an image - all pages that do not have images will not have an `og:image` tag.
* Example 3: In the config, `ogp_first_image` is enabled. Some of the SRT files have images with alt texts, others don't. Sphinx will create `og:image` and `og:image:alt` tags with the information included in the corresponding SRT file. For SRT files that include an image but no alt text, Sphinx will use the existing fallback mechanism to create the `og:image:alt` tag either from a custom alt text supplied in the config, from `site_name`, or from `htp.text`.

This pull request also includes a new test and a short explanation in the readme.