### PR TITLE
Avoid printing og:description if empty

### DIFF
--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -92,7 +92,8 @@ def get_tags(
         tags += make_tag("og:site_name", site_name)
 
     # description tag
-    tags += make_tag("og:description", description)
+    if description:
+        tags += make_tag("og:description", description)
 
     # image tag
     # Get basic values from config


### PR DESCRIPTION
This is a minimal PR to check if `og:description` is empty and avoid printing an empty tag.