### PR TITLE
Skipping code blocks and fixing docs build.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-myst-parser==0.13.0
-furo==2020.12.30b24
-sphinx==3.4.0
+myst-parser==0.15.2
+furo==2021.11.12.1
+sphinx==4.2.0
 ./

--- a/sphinxext/opengraph/descriptionparser.py
+++ b/sphinxext/opengraph/descriptionparser.py
@@ -67,7 +67,7 @@ class DescriptionParser(nodes.NodeVisitor):
             if node.astext() in self.known_titles:
                 raise nodes.SkipNode
 
-        if isinstance(node, nodes.raw):
+        if isinstance(node, nodes.raw) or isinstance(node.parent, nodes.literal_block):
             raise nodes.SkipNode
 
         # Only include leaf nodes in the description

--- a/tests/roots/test-skip-code-block/conf.py
+++ b/tests/roots/test-skip-code-block/conf.py
@@ -1,0 +1,9 @@
+extensions = ["sphinxext.opengraph"]
+
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+html_theme = "basic"
+
+ogp_site_url = "http://example.org/"
+ogp_description_length = 100

--- a/tests/roots/test-skip-code-block/index.rst
+++ b/tests/roots/test-skip-code-block/index.rst
@@ -1,0 +1,7 @@
+This text should be included.
+
+.. code-block:: html
+
+    <p> This text should be skipped. </p>
+
+This text should also be included.

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -127,6 +127,16 @@ def test_skip_raw(og_meta_tags):
     )
 
 
+@pytest.mark.sphinx("html", testroot="skip-code-block")
+def test_skip_code_block(og_meta_tags):
+    description = get_tag_content(og_meta_tags, "description")
+    assert "<p>" not in description
+    assert (
+        description
+        == "This text should be included. This text should also be included."
+    )
+
+
 # use same as simple, as configuration is identical to overriden
 @pytest.mark.sphinx("html", testroot="simple")
 def test_rtd_override(app: Sphinx, monkeypatch):


### PR DESCRIPTION
While working on another PR I ran into this bug on my test website. I had a test document with only an HTML code block and found out unescaped HTML was added to the meta tag:

```html
<meta property="og:description" content="<meta property="og:image" content="_images/normal.jpg" /> <img alt="_images/normal.jpg" src="_images/normal.jpg" />" />
<meta property="og:image" content="_images/normal.jpg" />
```

Fixing this by skipping literal blocks.

Also fixed docs build. I was getting the exception: `AttributeError: 'Values' object has no attribute 'section_self_link'`

This was caused by https://github.com/sphinx-doc/sphinx/issues/9825. Updating dependencies fixed the issue.