### PR TITLE
Escape quotations in Open Graph description when smart quotes are disabled.

### DIFF
--- a/sphinxext/opengraph/descriptionparser.py
+++ b/sphinxext/opengraph/descriptionparser.py
@@ -125,4 +125,4 @@ def get_description(
     mcv = DescriptionParser(description_length, known_titles, document)
     doctree.walkabout(mcv)
     # Parse quotation so they won't break html tags if smart quotes are disabled
-    return mcv.description.replace("\"", "&quot;")
+    return mcv.description.replace('"', "&quot;")

--- a/sphinxext/opengraph/descriptionparser.py
+++ b/sphinxext/opengraph/descriptionparser.py
@@ -124,4 +124,5 @@ def get_description(
 
     mcv = DescriptionParser(description_length, known_titles, document)
     doctree.walkabout(mcv)
-    return mcv.description
+    # Parse quotation so they won't break html tags if smart quotes are disabled
+    return mcv.description.replace("\"", "&quot;")

--- a/tests/roots/test-quotation-marks/conf.py
+++ b/tests/roots/test-quotation-marks/conf.py
@@ -1,0 +1,10 @@
+extensions = ["sphinxext.opengraph"]
+
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+html_theme = "basic"
+
+smartquotes = False
+
+ogp_site_url = "http://example.org/"

--- a/tests/roots/test-quotation-marks/index.rst
+++ b/tests/roots/test-quotation-marks/index.rst
@@ -1,0 +1,1 @@
+"This text should appear in escaped quotation marks" This text should still appear as well "while this is once again in quotations"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -148,6 +148,15 @@ def test_skip_code_block(og_meta_tags):
         == "This text should be included. This text should also be included."
     )
 
+@pytest.mark.sphinx("html", testroot="quotation-marks")
+def test_quotation_marks(og_meta_tags):
+    # If smart quotes are disabled and the quotes aren't properly escaped, bs4 will fail to parse the tag and the content will be a empty string
+    description = get_tag_content(og_meta_tags, "description")
+
+    assert (
+        description
+        == "\"This text should appear in escaped quotation marks\" This text should still appear as well \"while this is once again in quotations\""
+    )
 
 # use same as simple, as configuration is identical to overriden
 @pytest.mark.sphinx("html", testroot="simple")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -148,6 +148,7 @@ def test_skip_code_block(og_meta_tags):
         == "This text should be included. This text should also be included."
     )
 
+
 @pytest.mark.sphinx("html", testroot="quotation-marks")
 def test_quotation_marks(og_meta_tags):
     # If smart quotes are disabled and the quotes aren't properly escaped, bs4 will fail to parse the tag and the content will be a empty string
@@ -155,8 +156,9 @@ def test_quotation_marks(og_meta_tags):
 
     assert (
         description
-        == "\"This text should appear in escaped quotation marks\" This text should still appear as well \"while this is once again in quotations\""
+        == '"This text should appear in escaped quotation marks" This text should still appear as well "while this is once again in quotations"'
     )
+
 
 # use same as simple, as configuration is identical to overriden
 @pytest.mark.sphinx("html", testroot="simple")


### PR DESCRIPTION
Fixes #46 
Replaces the normal quotation mark with the proper HTML `&quot;`. This problem would only appear when smart quotes are disabled in Sphinx via `smartquotes = False`