### PR TITLE
Add per-file overrides using field lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Page contents
 =============
 ```
 
-### Arbitrary Tags
+### Arbitrary Tags[^1]
 Additionally, you can use field lists to add any arbitrary OpenGraph tag not supported by the extension. The syntax for arbitrary tags is the same with `:og:tag: content`. For Example:
 
 ```rst
@@ -104,4 +104,4 @@ Page contents
 =============
 ```
 
-[^1]: Note: Relative file paths for images are currently converted to be relative to the root of the website as defined by `ogp_site_name` ***not*** the source reStructuredText file. Additionally, relative file paths for videos and audio are currently **not** supported please use an absolute path instead.
+[^1]: Note: Relative file paths for images, videos and audio are currently **not** supported when using field lists. Please use an absolute path instead.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ These are some overrides that can be used, you can actually override any tag and
 * `:og:type:`
   * Override the type of the page, for the list of available types take a look at https://ogp.me/#types.
 * `:ogp:image:`
-  * Set the image for the page. Note: Relative file paths are ***not*** currently supported when using field lists.
+  * Set the image for the page.[^1]
 * `:ogp:image:alt:`
   * Sets the alt text. Will be ignored if there is no image set.
 
@@ -97,11 +97,11 @@ Page contents
 ### Arbitrary Tags
 Additionally, you can use field lists to add any arbitrary OpenGraph tag not supported by the extension. The syntax for arbitrary tags is the same with `:og:tag: content`. For Example:
 
-Note: Relative file paths are ***not*** currently supported for images, videos and audio when using field lists.
-
 ```rst
 :og:video: http://example.org/video.mp4
 
 Page contents
 =============
 ```
+
+[^1]: Note: Relative file paths for images are currently converted to be relative to the root of the website as defined by `ogp_site_name` ***not*** the source reStructuredText file. Additionally, relative file paths for videos and audio are currently **not** supported please use an absolute path instead.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Users hosting documentation on Read The Docs *do not* need to set any of the fol
 * `ogp_site_name`
     * This is not required. Name of the site. This is displayed above the title.
 * `ogp_image`
-    * This is not required. Link to image to show. Note that all relative paths are converted to be relative to the root of the html output.
+    * This is not required. Link to image to show. Note that all relative paths are converted to be relative to the root of the html output as defined by `ogp_site_name.
 * `ogp_image_alt`
     * This is not required. Alt text for image. Defaults to using `ogp_site_name` or the document's title as alt text, if available. Set to `False` if you want to turn off alt text completely.
 * `ogp_use_first_image`

--- a/README.md
+++ b/README.md
@@ -62,36 +62,37 @@ ogp_custom_meta_tags = [
 ```
 
 ## Per Page Overrides
-[Field lists](https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html) are used to allow you to override certain settings on each page.
+[Field lists](https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html) are used to allow you to override certain settings on each page and set unsupported arbitrary OpenGraph tags.
 
 Make sure you place the fields at the very start of the document such that Sphinx will pick them up and also won't build them into the html.
 
 ### Overrides
+These are some overrides that can be used, you can actually override any tag and field lists will always take priority.
 
-* `:ogp-description-length:`
-  * Configure the amount of characters to grab for the description of the page. If the value isn't a number it will fall back to `ogp_description_length`.
-* `:ogp-description:`
+* `:og_description_length:`
+  * Configure the amount of characters to grab for the description of the page. If the value isn't a number it will fall back to `ogp_description_length`. Note the slightly different syntax because this isn't directly an OpenGraph tag.
+* `:og:description:`
   * Lets you override the description of the page.
-* `:ogp-title:`
+* `:og:title:`
   * Lets you override the title of the page.
-* `:ogp-type:`
+* `:og:type:`
   * Override the type of the page, for the list of available types take a look at https://ogp.me/#types.
-* `:ogp-image:`
+* `:ogp:image:`
   * Set the image for the page.
-* `:ogp-image-alt:`
-  * Will be ignored if the image isn't set with the above field, if the image is set, sets the alt text for it.
+* `:ogp:image:alt:`
+  * Sets the alt text. Will be ignored if there is no image set.
 
 ### Example
 Remember that the fields **must** be placed at the very start of the file. You can verify Sphinx has picked up the fields if they aren't shown in the final html file.
 
 ```rst
-:ogp-description: New description
-:ogp-image: http://example.org/image.png
-:ogp-image-alt: Example Image
+:og:description: New description
+:og:image: http://example.org/image.png
+:og:image:alt: Example Image
 ```
 
-## Arbitrary Tags
-Additionally, you can use field lists to add any arbitrary OpenGraph tag not supported by the extension. The syntax for arbitrary tags is `:og:tag: content`. For Example:
+### Arbitrary Tags
+Additionally, you can use field lists to add any arbitrary OpenGraph tag not supported by the extension. The syntax for arbitrary tags is the same with `:og:tag: content`. For Example:
 
 ```rst
 :og:video: http://example.org/video.mp4

--- a/README.md
+++ b/README.md
@@ -89,3 +89,10 @@ Remember that the fields **must** be placed at the very start of the file. You c
 :ogp-image: http://example.org/image.png
 :ogp-image-alt: Example Image
 ```
+
+## Arbitrary Tags
+Additionally, you can use field lists to add any arbitrary OpenGraph tag not supported by the extension. The syntax for arbitrary tags is `:og:tag: content`. For Example:
+
+```rst
+:og:video: http://example.org/video.mp4
+```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Users hosting documentation on Read The Docs *do not* need to set any of the fol
 * `ogp_site_name`
     * This is not required. Name of the site. This is displayed above the title.
 * `ogp_image`
-    * This is not required. Link to image to show.
+    * This is not required. Link to image to show. Note that all relative paths are converted to be relative to the root of the html output.
 * `ogp_image_alt`
     * This is not required. Alt text for image. Defaults to using `ogp_site_name` or the document's title as alt text, if available. Set to `False` if you want to turn off alt text completely.
 * `ogp_use_first_image`
@@ -78,7 +78,7 @@ These are some overrides that can be used, you can actually override any tag and
 * `:og:type:`
   * Override the type of the page, for the list of available types take a look at https://ogp.me/#types.
 * `:ogp:image:`
-  * Set the image for the page.
+  * Set the image for the page. Note: Relative file paths are ***not*** currently supported when using field lists.
 * `:ogp:image:alt:`
   * Sets the alt text. Will be ignored if there is no image set.
 
@@ -92,12 +92,16 @@ Remember that the fields **must** be placed at the very start of the file. You c
 
 Page contents
 =============
+```
 
 ### Arbitrary Tags
 Additionally, you can use field lists to add any arbitrary OpenGraph tag not supported by the extension. The syntax for arbitrary tags is the same with `:og:tag: content`. For Example:
+
+Note: Relative file paths are ***not*** currently supported for images, videos and audio when using field lists.
 
 ```rst
 :og:video: http://example.org/video.mp4
 
 Page contents
 =============
+```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Users hosting documentation on Read The Docs *do not* need to set any of the fol
     * This sets the ogp type attribute, for more information on the types available please take a look at https://ogp.me/#types. By default it is set to `website`, which should be fine for most use cases.
 * `ogp_custom_meta_tags`
     * This is not required. List of custom html snippets to insert.
-
+    
 ## Example Config
 
 ### Simple Config
@@ -59,4 +59,33 @@ ogp_custom_meta_tags = [
     '<meta property="og:ignore_canonical" content="true" />',
 ]
 
+```
+
+## Per Page Overrides
+[Field lists](https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html) are used to allow you to override certain settings on each page.
+
+Make sure you place the fields at the very start of the document such that Sphinx will pick them up and also won't build them into the html.
+
+### Overrides
+
+* `:ogp-description-length:`
+  * Configure the amount of characters to grab for the description of the page. If the value isn't a number it will fall back to `ogp_description_length`.
+* `:ogp-description:`
+  * Lets you override the description of the page.
+* `:ogp-title:`
+  * Lets you override the title of the page.
+* `:ogp-type:`
+  * Override the type of the page, for the list of available types take a look at https://ogp.me/#types.
+* `:ogp-image:`
+  * Set the image for the page.
+* `:ogp-image-alt:`
+  * Will be ignored if the image isn't set with the above field, if the image is set, sets the alt text for it.
+
+### Example
+Remember that the fields **must** be placed at the very start of the file. You can verify Sphinx has picked up the fields if they aren't shown in the final html file.
+
+```rst
+:ogp-description: New description
+:ogp-image: http://example.org/image.png
+:ogp-image-alt: Example Image
 ```

--- a/README.md
+++ b/README.md
@@ -89,11 +89,15 @@ Remember that the fields **must** be placed at the very start of the file. You c
 :og:description: New description
 :og:image: http://example.org/image.png
 :og:image:alt: Example Image
-```
+
+Page contents
+=============
 
 ### Arbitrary Tags
 Additionally, you can use field lists to add any arbitrary OpenGraph tag not supported by the extension. The syntax for arbitrary tags is the same with `:og:tag: content`. For Example:
 
 ```rst
 :og:video: http://example.org/video.mp4
-```
+
+Page contents
+=============

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -42,6 +42,8 @@ def get_tags(
 ) -> str:
     # Get field lists for per-poge overrides
     fields = context["meta"]
+    if fields is None:
+        fields = {}
 
     # Set length of description
     try:

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -65,7 +65,9 @@ def get_tags(
     tags = "\n  "
 
     # title tag
-    tags += make_tag("og:title", title)
+    tags += make_tag(
+        "og:title", title if "ogp-title" not in fields else fields["ogp-title"]
+    )
 
     # type tag
     tags += make_tag(

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -114,12 +114,6 @@ def get_tags(
         ogp_use_first_image = config["ogp_use_first_image"]
         ogp_image_alt = fields.get("og:image:alt", config["ogp_image_alt"])
 
-        if image_url:
-            image_url_parsed = urlparse(image_url)
-            if not image_url_parsed.scheme:
-                # Relative image path detected. Make absolute.
-                image_url = urljoin(config["ogp_site_url"], image_url_parsed.path)
-
     fields.pop("og:image:alt", None)
 
     if ogp_use_first_image:
@@ -132,6 +126,11 @@ def get_tags(
             ogp_image_alt = first_image.get("alt", None)
 
     if image_url:
+        if image_url:
+            image_url_parsed = urlparse(image_url)
+            if not image_url_parsed.scheme:
+                # Relative image path detected. Make absolute.
+                image_url = urljoin(config["ogp_site_url"], image_url_parsed.path)
         tags["og:image"] = image_url
 
         # Add image alt text (either provided by config or from site_name)

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -113,6 +113,13 @@ def get_tags(
         image_url = config["ogp_image"]
         ogp_use_first_image = config["ogp_use_first_image"]
         ogp_image_alt = fields.get("og:image:alt", config["ogp_image_alt"])
+
+        if image_url:
+            image_url_parsed = urlparse(image_url)
+            if not image_url_parsed.scheme:
+                # Relative image path detected. Make absolute.
+                image_url = urljoin(config["ogp_site_url"], image_url_parsed.path)
+
     fields.pop("og:image:alt", None)
 
     if ogp_use_first_image:
@@ -125,10 +132,6 @@ def get_tags(
             ogp_image_alt = first_image.get("alt", None)
 
     if image_url:
-        image_url_parsed = urlparse(image_url)
-        if not image_url_parsed.scheme:
-            # Relative image path detected. Make absolute.
-            image_url = urljoin(config["ogp_site_url"], image_url_parsed.path)
         tags["og:image"] = image_url
 
         # Add image alt text (either provided by config or from site_name)

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -144,8 +144,7 @@ def get_tags(
 
     return (
         "\n"
-        + "\n".join([make_tag(p, c) for p, c in tags.items()])
-        + "\n".join(config["ogp_custom_meta_tags"])
+        + "\n".join([make_tag(p, c) for p, c in tags.items()] + config["ogp_custom_meta_tags"])
     )
 
 

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -26,16 +26,12 @@ IMAGE_MIME_TYPES = {
     "heif": "image/heif",
     "tiff": "image/tiff",
 }
-TAG_LIST = []
 
 
 def make_tag(property: str, content: str) -> str:
     # Parse quotation, so they won't break html tags if smart quotes are disabled
-    if property not in TAG_LIST:
-        TAG_LIST.append(property)
-        content = content.replace('"', "&quot;")
-        return f'<meta property="{property}" content="{content}" />\n  '
-    return ""
+    content = content.replace('"', "&quot;")
+    return f'<meta property="{property}" content="{content}" />\n  '
 
 
 def make_arbitrary_tags(fields: Dict[str, Any]) -> str:
@@ -53,7 +49,6 @@ def get_tags(
     doctree: nodes.document,
     config: Dict[str, Any],
 ) -> str:
-    TAG_LIST.clear()
     # Get field lists for per-poge overrides
     fields = context["meta"]
     if fields is None:

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -47,7 +47,9 @@ def get_tags(
 
     # Set length of description
     try:
-        desc_len = int(fields.get("ogp-description-length", config["ogp_description_length"]))
+        desc_len = int(
+            fields.get("ogp-description-length", config["ogp_description_length"])
+        )
     except ValueError:
         desc_len = DEFAULT_DESCRIPTION_LENGTH
 
@@ -56,7 +58,10 @@ def get_tags(
     title_excluding_html = get_title(context["title"], skip_html_tags=True)
 
     # Parse/walk doctree for metadata (tag/description)
-    description = fields.get("ogp-description", get_description(doctree, desc_len, [title, title_excluding_html]))
+    description = fields.get(
+        "ogp-description",
+        get_description(doctree, desc_len, [title, title_excluding_html]),
+    )
 
     tags = "\n  "
 
@@ -142,6 +147,9 @@ def get_tags(
     return tags
 
 
+from sphinx.util import logging
+
+
 def html_page_context(
     app: Sphinx,
     pagename: str,
@@ -149,6 +157,8 @@ def html_page_context(
     context: Dict[str, Any],
     doctree: nodes.document,
 ) -> None:
+    logger = logging.getLogger(__name__)
+    logger.info(context.get("meta"))
     if doctree:
         context["metatags"] += get_tags(app, context, doctree, app.config)
 

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -47,10 +47,7 @@ def get_tags(
 
     # Set length of description
     try:
-        try:
-            desc_len = int(fields["ogp-description-length"])
-        except (ValueError, KeyError):
-            desc_len = int(config["ogp_description_length"])
+        desc_len = int(fields.get("ogp-description-length", config["ogp_description_length"]))
     except ValueError:
         desc_len = DEFAULT_DESCRIPTION_LENGTH
 
@@ -59,23 +56,15 @@ def get_tags(
     title_excluding_html = get_title(context["title"], skip_html_tags=True)
 
     # Parse/walk doctree for metadata (tag/description)
-    if "ogp-description" in fields:
-        description = fields["ogp-description"]
-    else:
-        description = get_description(doctree, desc_len, [title, title_excluding_html])
+    description = fields.get("ogp-description", get_description(doctree, desc_len, [title, title_excluding_html]))
 
     tags = "\n  "
 
     # title tag
-    tags += make_tag(
-        "og:title", title if "ogp-title" not in fields else fields["ogp-title"]
-    )
+    tags += make_tag("og:title", fields.get("ogp-title", title))
 
     # type tag
-    tags += make_tag(
-        "og:type",
-        config["ogp_type"] if "ogp-type" not in fields else fields["ogp-type"],
-    )
+    tags += make_tag("og:type", fields.get("ogp-type", config["ogp_type"]))
 
     if os.getenv("READTHEDOCS") and config["ogp_site_url"] is None:
         # readthedocs uses html_baseurl for sphinx > 1.8
@@ -104,11 +93,7 @@ def get_tags(
     tags += make_tag("og:url", page_url)
 
     # site name tag
-    site_name = (
-        config["ogp_site_name"]
-        if "ogp-site-name" not in fields
-        else fields["ogp-site-name"]
-    )
+    site_name = fields.get("ogp-site-name", config["ogp_site_name"])
     if site_name:
         tags += make_tag("og:site_name", site_name)
 
@@ -121,7 +106,7 @@ def get_tags(
     if "ogp-image" in fields:
         image_url = fields["ogp-image"]
         ogp_use_first_image = False
-        ogp_image_alt = fields["ogp-image-alt"] if "ogp-image-alt" in fields else None
+        ogp_image_alt = fields.get("ogp-image-alt")
     else:
         image_url = config["ogp_image"]
         ogp_use_first_image = config["ogp_use_first_image"]

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -126,7 +126,8 @@ def get_tags(
             ogp_image_alt = first_image.get("alt", None)
 
     if image_url:
-        if image_url:
+        # temporarily disable relative image paths with field lists
+        if image_url and "og:image" not in fields:
             image_url_parsed = urlparse(image_url)
             if not image_url_parsed.scheme:
                 # Relative image path detected. Make absolute.

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -109,11 +109,11 @@ def get_tags(
         ogp_use_first_image = False
         ogp_image_alt = fields.get("og:image:alt")
         fields.pop("og:image", None)
-        fields.pop("og:image:alt", None)
     else:
         image_url = config["ogp_image"]
         ogp_use_first_image = config["ogp_use_first_image"]
-        ogp_image_alt = config["ogp_image_alt"]
+        ogp_image_alt = fields.get("og:image:alt", config["ogp_image_alt"])
+    fields.pop("og:image:alt", None)
 
     if ogp_use_first_image:
         first_image = doctree.next_node(nodes.image)

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -29,6 +29,8 @@ IMAGE_MIME_TYPES = {
 
 
 def make_tag(property: str, content: str) -> str:
+    # Parse quotation, so they won't break html tags if smart quotes are disabled
+    content = content.replace('"', "&quot;")
     return f'<meta property="{property}" content="{content}" />\n  '
 
 

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -34,6 +34,15 @@ def make_tag(property: str, content: str) -> str:
     return f'<meta property="{property}" content="{content}" />\n  '
 
 
+def make_arbitrary_tags(fields: Dict[str, Any]) -> str:
+    tags = ""
+    for name, content in fields.items():
+        if name.startswith("og:"):
+            tags += make_tag(name, content)
+
+    return tags
+
+
 def get_tags(
     app: Sphinx,
     context: Dict[str, Any],
@@ -141,13 +150,13 @@ def get_tags(
         elif ogp_image_alt is None and title:
             tags += make_tag("og:image:alt", title)
 
+    # arbitrary tags
+    tags += make_arbitrary_tags(fields)
+
     # custom tags
     tags += "\n".join(config["ogp_custom_meta_tags"])
 
     return tags
-
-
-from sphinx.util import logging
 
 
 def html_page_context(
@@ -157,8 +166,6 @@ def html_page_context(
     context: Dict[str, Any],
     doctree: nodes.document,
 ) -> None:
-    logger = logging.getLogger(__name__)
-    logger.info(context.get("meta"))
     if doctree:
         context["metatags"] += get_tags(app, context, doctree, app.config)
 

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -26,12 +26,16 @@ IMAGE_MIME_TYPES = {
     "heif": "image/heif",
     "tiff": "image/tiff",
 }
+TAG_LIST = []
 
 
 def make_tag(property: str, content: str) -> str:
     # Parse quotation, so they won't break html tags if smart quotes are disabled
-    content = content.replace('"', "&quot;")
-    return f'<meta property="{property}" content="{content}" />\n  '
+    if property not in TAG_LIST:
+        TAG_LIST.append(property)
+        content = content.replace('"', "&quot;")
+        return f'<meta property="{property}" content="{content}" />\n  '
+    return ""
 
 
 def make_arbitrary_tags(fields: Dict[str, Any]) -> str:
@@ -49,6 +53,7 @@ def get_tags(
     doctree: nodes.document,
     config: Dict[str, Any],
 ) -> str:
+    TAG_LIST.clear()
     # Get field lists for per-poge overrides
     fields = context["meta"]
     if fields is None:

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -40,7 +40,7 @@ def get_tags(
     doctree: nodes.document,
     config: Dict[str, Any],
 ) -> str:
-    # Get field lists for per-poge overrides
+    # Get field lists for per-page overrides
     fields = context["meta"]
     if fields is None:
         fields = {}

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -142,9 +142,8 @@ def get_tags(
     # arbitrary tags and overrides
     tags.update({k: v for k, v in fields.items() if k.startswith("og:")})
 
-    return (
-        "\n"
-        + "\n".join([make_tag(p, c) for p, c in tags.items()] + config["ogp_custom_meta_tags"])
+    return "\n" + "\n".join(
+        [make_tag(p, c) for p, c in tags.items()] + config["ogp_custom_meta_tags"]
     )
 
 

--- a/sphinxext/opengraph/descriptionparser.py
+++ b/sphinxext/opengraph/descriptionparser.py
@@ -18,7 +18,7 @@ class DescriptionParser(nodes.NodeVisitor):
 
         # Hack to prevent requirement for the doctree to be passed in.
         # It's only used by doctree.walk(...) to print debug messages.
-        if document == None:
+        if document is None:
 
             class document_cls:
                 class reporter:
@@ -124,5 +124,4 @@ def get_description(
 
     mcv = DescriptionParser(description_length, known_titles, document)
     doctree.walkabout(mcv)
-    # Parse quotation so they won't break html tags if smart quotes are disabled
-    return mcv.description.replace('"', "&quot;")
+    return mcv.description

--- a/tests/roots/test-arbitrary-tags/conf.py
+++ b/tests/roots/test-arbitrary-tags/conf.py
@@ -1,0 +1,8 @@
+extensions = ["sphinxext.opengraph"]
+
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+html_theme = "basic"
+
+ogp_site_url = "http://example.org/"

--- a/tests/roots/test-arbitrary-tags/index.rst
+++ b/tests/roots/test-arbitrary-tags/index.rst
@@ -1,5 +1,4 @@
 :og:video: http://example.org/video.mp4
 :og:video:type: video/mp4
-:og:url: http://example.com/
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/roots/test-arbitrary-tags/index.rst
+++ b/tests/roots/test-arbitrary-tags/index.rst
@@ -1,0 +1,4 @@
+:og:video: http://example.org/video.mp4
+:og:video:type: video/mp4
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/roots/test-arbitrary-tags/index.rst
+++ b/tests/roots/test-arbitrary-tags/index.rst
@@ -1,4 +1,5 @@
 :og:video: http://example.org/video.mp4
 :og:video:type: video/mp4
+:og:url: http://example.com/
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/roots/test-overrides-complex/conf.py
+++ b/tests/roots/test-overrides-complex/conf.py
@@ -1,0 +1,10 @@
+extensions = ["sphinxext.opengraph"]
+
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+html_theme = "basic"
+
+ogp_site_name = "Example's Docs!"
+ogp_site_url = "http://example.org/"
+ogp_image_alt = "Example Alt Text"

--- a/tests/roots/test-overrides-complex/index.rst
+++ b/tests/roots/test-overrides-complex/index.rst
@@ -1,0 +1,6 @@
+:ogp-description-length: 10
+:ogp-image: img/sample.jpg
+:ogp-image-alt: Overridden Alt Text
+Lorem Ipsum
+===========
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/roots/test-overrides-complex/index.rst
+++ b/tests/roots/test-overrides-complex/index.rst
@@ -1,6 +1,7 @@
-:ogp-description-length: 10
-:ogp-image: img/sample.jpg
-:ogp-image-alt: Overridden Alt Text
+:ogp_description_length: 10
+:og:image: img/sample.jpg
+:og:image:alt: Overridden Alt Text
+
 Lorem Ipsum
 ===========
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/roots/test-overrides-simple/conf.py
+++ b/tests/roots/test-overrides-simple/conf.py
@@ -1,0 +1,11 @@
+extensions = ["sphinxext.opengraph"]
+
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+html_theme = "basic"
+
+ogp_site_name = "Example's Docs!"
+ogp_site_url = "http://example.org/"
+ogp_image = "http://example.org/image.png"
+ogp_type = "book"

--- a/tests/roots/test-overrides-simple/index.rst
+++ b/tests/roots/test-overrides-simple/index.rst
@@ -1,7 +1,8 @@
-:ogp-description: Overridden description
-:ogp-title: Overridden Title
-:ogp-type: article
-:ogp-image: http://example.org/overridden-image.png
+:og:description: Overridden description
+:og:title: Overridden Title
+:og:type: article
+:og:image: http://example.org/overridden-image.png
+
 Lorem Ipsum
 ===========
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/roots/test-overrides-simple/index.rst
+++ b/tests/roots/test-overrides-simple/index.rst
@@ -1,0 +1,7 @@
+:ogp-description: Overridden description
+:ogp-title: Overridden Title
+:ogp-type: article
+:ogp-image: http://example.org/overridden-image.png
+Lorem Ipsum
+===========
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -184,6 +184,8 @@ def test_overrides_complex(og_meta_tags):
 def test_arbitrary_tags(og_meta_tags):
     assert get_tag_content(og_meta_tags, "video") == "http://example.org/video.mp4"
     assert get_tag_content(og_meta_tags, "video:type") == "video/mp4"
+    assert get_tag_content(og_meta_tags, "url") == "http://example.org/index.html"
+    assert len([tag for tag in og_meta_tags if tag.get("property") == "og:url"]) == 1
 
 
 # use same as simple, as configuration is identical to overriden

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -160,6 +160,26 @@ def test_quotation_marks(og_meta_tags):
     )
 
 
+@pytest.mark.sphinx("html", testroot="overrides-simple")
+def test_overrides_simple(og_meta_tags):
+    assert get_tag_content(og_meta_tags, "description") == "Overridden description"
+    assert get_tag_content(og_meta_tags, "title") == "Overridden Title"
+    assert get_tag_content(og_meta_tags, "type") == "article"
+    assert (
+        get_tag_content(og_meta_tags, "image")
+        == "http://example.org/overridden-image.png"
+    )
+    # Make sure alt text still works even when overriding the image
+    assert get_tag_content(og_meta_tags, "image:alt") == "Example's Docs!"
+
+
+@pytest.mark.sphinx("html", testroot="overrides-complex")
+def test_overrides_complex(og_meta_tags):
+    assert len(get_tag_content(og_meta_tags, "description")) == 10
+    assert get_tag_content(og_meta_tags, "image") == "http://example.org/img/sample.jpg"
+    assert get_tag_content(og_meta_tags, "image:alt") == "Overridden Alt Text"
+
+
 # use same as simple, as configuration is identical to overriden
 @pytest.mark.sphinx("html", testroot="simple")
 def test_rtd_override(app: Sphinx, monkeypatch):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -180,6 +180,12 @@ def test_overrides_complex(og_meta_tags):
     assert get_tag_content(og_meta_tags, "image:alt") == "Overridden Alt Text"
 
 
+@pytest.mark.sphinx("html", testroot="arbitrary-tags")
+def test_arbitrary_tags(og_meta_tags):
+    assert get_tag_content(og_meta_tags, "video") == "http://example.org/video.mp4"
+    assert get_tag_content(og_meta_tags, "video:type") == "video/mp4"
+
+
 # use same as simple, as configuration is identical to overriden
 @pytest.mark.sphinx("html", testroot="simple")
 def test_rtd_override(app: Sphinx, monkeypatch):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -184,8 +184,6 @@ def test_overrides_complex(og_meta_tags):
 def test_arbitrary_tags(og_meta_tags):
     assert get_tag_content(og_meta_tags, "video") == "http://example.org/video.mp4"
     assert get_tag_content(og_meta_tags, "video:type") == "video/mp4"
-    assert get_tag_content(og_meta_tags, "url") == "http://example.org/index.html"
-    assert len([tag for tag in og_meta_tags if tag.get("property") == "og:url"]) == 1
 
 
 # use same as simple, as configuration is identical to overriden


### PR DESCRIPTION
Use field lists to implement per page overrides
Closes #11.
It seems like `__init__.py` might be due for a slight rewrite after this change.
