### PR TITLE
fix og:url for "dirhtml" builder

### DIFF
--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -88,9 +88,12 @@ def get_tags(
 
     # url tag
     # Get the URL of the specific page
-    page_url = urljoin(
-        config["ogp_site_url"], context["pagename"] + context["file_suffix"]
-    )
+    if context["builder"] == "dirhtml":
+        page_url = urljoin(config["ogp_site_url"], context["pagename"] + "/")
+    else:
+        page_url = urljoin(
+            config["ogp_site_url"], context["pagename"] + context["file_suffix"]
+        )
     tags["og:url"] = page_url
 
     # site name tag

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -32,6 +32,11 @@ def test_site_url(og_meta_tags):
     assert get_tag_content(og_meta_tags, "url") == "http://example.org/index.html"
 
 
+@pytest.mark.sphinx("dirhtml", testroot="simple")
+def test_dirhtml_url(og_meta_tags):
+    assert get_tag_content(og_meta_tags, "url") == "http://example.org/index/"
+
+
 @pytest.mark.sphinx("html", testroot="image")
 def test_image(og_meta_tags):
     assert get_tag_content(og_meta_tags, "image") == "http://example.org/image.png"


### PR DESCRIPTION
The "dirhtml" builder correctly uses ".html" as file suffix,
but the file suffix should not be part of the URL.
We want ".../file_name/" as URL in this case, not
".../file_name.html".

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>