### PR TITLE
Fix first_image not resolving correctly when in subdirectories and ogp_image is defined.

### DIFF
--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -128,6 +128,8 @@ def get_tags(
         ):
             image_url = first_image["uri"]
             ogp_image_alt = first_image.get("alt", None)
+        else:
+            first_image = None
 
     if image_url:
         # temporarily disable relative image paths with field lists
@@ -137,7 +139,7 @@ def get_tags(
                 # Relative image path detected, relative to the source. Make absolute.
                 if first_image:
                     root = page_url
-                else:
+                else:  # ogp_image is set
                     # ogp_image is defined as being relative to the site root.
                     # This workaround is to keep that functionality from breaking.
                     root = config["ogp_site_url"]

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -119,6 +119,7 @@ def get_tags(
 
     fields.pop("og:image:alt", None)
 
+    first_image = None
     if ogp_use_first_image:
         first_image = doctree.next_node(nodes.image)
         if (
@@ -134,12 +135,12 @@ def get_tags(
             image_url_parsed = urlparse(image_url)
             if not image_url_parsed.scheme:
                 # Relative image path detected, relative to the source. Make absolute.
-                if config["ogp_image"]:
+                if first_image:
+                    root = page_url
+                else:
                     # ogp_image is defined as being relative to the site root.
                     # This workaround is to keep that functionality from breaking.
                     root = config["ogp_site_url"]
-                else:
-                    root = page_url
 
                 image_url = urljoin(root, image_url_parsed.path)
             tags["og:image"] = image_url

--- a/tests/roots/test-image-rel-paths/conf.py
+++ b/tests/roots/test-image-rel-paths/conf.py
@@ -7,4 +7,5 @@ html_theme = "basic"
 
 ogp_site_name = "Example's Docs!"
 ogp_site_url = "http://example.org/en/latest/"
+ogp_image = "_static/image33.png"
 ogp_use_first_image = True


### PR DESCRIPTION
Fixes #59 again.
The fix in #61 doesn't work properly when a `ogp_image` is defined in the config.
Swaps the order of the if's and fixes the tests so it will detect this case. 