### PR TITLE
Add support for Python 3.10 and 3.11, drop EOL 3.6

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7',  '3.8', '3.9', 'pypy3']
+        python-version: ['3.6', '3.7',  '3.8', '3.9', 'pypy3.8']
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,8 +13,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Black
@@ -28,9 +28,9 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7',  '3.8', '3.9', 'pypy3']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -50,11 +50,11 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
       - name: Install dependencies
         run: |
           pip install -r docs/requirements.txt
@@ -68,11 +68,11 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'refs/tags/') && github.repository_owner	== 'wpilibsuite'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.7'
       - name: Install Dependencies

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.x'
     - name: Black
       run: |
         pip install black
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7',  '3.8', '3.9', 'pypy3.8']
+        python-version: ['3.6', '3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.x'
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
+        python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 sphinx
-wheel==0.34.2
-pytest==5.4.3
-beautifulsoup4==4.9.1
-setuptools==47.3.1
+wheel==0.37.1
+pytest==7.0.1 # 7.0.1 is the last to support EOL Python 3.6
+beautifulsoup4==4.11.1
+setuptools==59.6.0 # 59.6.0 is the last to support EOL Python 3.6

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 sphinx
 wheel==0.37.1
-pytest==7.0.1 # 7.0.1 is the last to support EOL Python 3.6
+pytest==7.1.3
 beautifulsoup4==4.11.1
-setuptools==59.6.0 # 59.6.0 is the last to support EOL Python 3.6
+setuptools==65.4.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-myst-parser==0.15.2
-furo==2021.11.12.1
-sphinx==4.2.0
+myst-parser==0.18.1
+furo==2022.9.29
+sphinx==5.2.3
 ./

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -53,5 +52,5 @@ setuptools.setup(
         "Topic :: Text Processing",
         "Topic :: Utilities",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python",
         "Topic :: Documentation :: Sphinx",
         "Topic :: Documentation",

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,7 @@ import setuptools
 try:
     ret = subprocess.run(
         "git describe --tags --abbrev=0",
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=True,
         shell=True,
     )
@@ -16,7 +15,7 @@ try:
 except:
     version = "main"
 
-with open("README.md", "r", encoding="utf-8") as readme:
+with open("README.md", encoding="utf-8") as readme:
     long_description = readme.read()
 
 setuptools.setup(

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -72,7 +72,7 @@ def get_tags(
         parse_result = urlparse(config["html_baseurl"])
 
         if config["html_baseurl"] is None:
-            raise EnvironmentError("ReadTheDocs did not provide a valid canonical URL!")
+            raise OSError("ReadTheDocs did not provide a valid canonical URL!")
 
         # Grab root url from canonical url
         config["ogp_site_url"] = urlunparse(

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -4,7 +4,7 @@ import conftest
 
 
 def get_tag(tags, tag_type):
-    return [tag for tag in tags if tag.get("property") == "og:{}".format(tag_type)][0]
+    return [tag for tag in tags if tag.get("property") == f"og:{tag_type}"][0]
 
 
 def get_tag_content(tags, tag_type):


### PR DESCRIPTION
Test 3.10 and 3.11, and add Trove classifiers.

Drop 3.6, EOL since 2021-09-03.

Also bump various versions:

* GitHub Actions
* docs dependencies
* dev dependencies
