### PR TITLE
Tidy up whitespace

### DIFF
--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -31,7 +31,7 @@ IMAGE_MIME_TYPES = {
 def make_tag(property: str, content: str) -> str:
     # Parse quotation, so they won't break html tags if smart quotes are disabled
     content = content.replace('"', "&quot;")
-    return f'<meta property="{property}" content="{content}" />\n  '
+    return f'<meta property="{property}" content="{content}" />'
 
 
 def get_tags(
@@ -158,8 +158,11 @@ def get_tags(
     # arbitrary tags and overrides
     tags.update({k: v for k, v in fields.items() if k.startswith("og:")})
 
-    return "\n" + "\n".join(
-        [make_tag(p, c) for p, c in tags.items()] + config["ogp_custom_meta_tags"]
+    return (
+        "\n".join(
+            [make_tag(p, c) for p, c in tags.items()] + config["ogp_custom_meta_tags"]
+        )
+        + "\n"
     )
 
 


### PR DESCRIPTION
# Before

The og meta tags have no indent and are double spaced:

```html
<!doctype html>
<html class="no-js">
  <head><meta charset="utf-8"/>
    <meta name="viewport" content="width=device-width,initial-scale=1"/>
    <meta name="color-scheme" content="light dark"><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />

<meta property="og:title" content="sphinxext-opengraph" />
  
<meta property="og:type" content="website" />
  
<meta property="og:url" content="index.html" />
  
<meta property="og:description" content="Build Code style: black Sphinx extension to generate OpenGraph metadata (https://ogp.me/) Installation: python -m pip install sphinxext-opengraph Usage: Just add sphinxext.opengraph to your extensi..." />
  <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" />

    <meta name="generator" content="sphinx-4.2.0, furo 2021.11.12.1"/>
        <title>sphinxext-opengraph 1.0 documentation</title>
      <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
    <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=cb850144ff767e23c5b2a31c47cdfe5847ae013d" />
    <link rel="stylesheet" type="text/css" href="_static/styles/furo-extensions.css?digest=0af69da206d614734f649b27d4cdc2dd6c31f41d" />
```

https://sphinxext-opengraph.readthedocs.io/en/latest/

# After

Give them four-space indents and only a single newline:

```html
<!doctype html>
<html class="no-js">
  <head><meta charset="utf-8"/>
    <meta name="viewport" content="width=device-width,initial-scale=1"/>
    <meta name="color-scheme" content="light dark"><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
    <meta property="og:title" content="sphinxext-opengraph" />
    <meta property="og:type" content="website" />
    <meta property="og:url" content="index.html" />
    <meta property="og:description" content="Build Code style: black Sphinx extension to generate OpenGraph metadata (https://ogp.me/) Installation: python -m pip install sphinxext-opengraph Usage: Just add sphinxext.opengraph to your extensi..." />
<link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" />

    <meta name="generator" content="sphinx-4.2.0, furo 2021.11.12.1"/>
        <title>sphinxext-opengraph 1.0 documentation</title>
      <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
    <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=cb850144ff767e23c5b2a31c47cdfe5847ae013d" />
    <link rel="stylesheet" type="text/css" href="_static/styles/furo-extensions.css?digest=0af69da206d614734f649b27d4cdc2dd6c31f41d" />
```
