### PR TITLE
Test multiple Sphinx and OS versions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -62,6 +62,8 @@ jobs:
       matrix:
         python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
         sphinx-version: ['>=2,<3', '>=3,<4', '>=4,<5', '>=5,<6', '==6.0.0b1']
+        exclude:
+          - { python-version: '3.7', sphinx-version: '==6.0.0b1' } # Sphinx 6 supports 3.8+
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -54,7 +54,7 @@ jobs:
           name: my-wheel
           path: dist/*.whl
 
-  test-extension:
+  test:
     needs: build-wheel
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,6 +23,7 @@ jobs:
   test-extension:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
         sphinx-version: ['>=2,<3', '>=3,<4', '>=4,<5', '>=5,<6', '==6.0.0b1']

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7',  '3.8', '3.9', 'pypy3']
+        python-version: ['3.6', '3.7',  '3.8', '3.9', 'pypy3.8']
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,6 +15,8 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+        cache: pip
+        cache-dependency-path: .github/workflows/workflow.yml
     - name: Black
       run: |
         pip install black
@@ -29,10 +31,14 @@ jobs:
         sphinx-version: ['>=2,<3', '>=3,<4', '>=4,<5', '>=5,<6', '==6.0.0b1']
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            .github/workflows/workflow.yml
+            dev-requirements.txt
       - name: Install dependencies
         run: |
           set -xe
@@ -41,7 +47,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r dev-requirements.txt
           python -m pip install "sphinx${{ matrix.sphinx-version }}"
-      - name: Install Package
+      - name: Install package
         run: |
           python -m pip install .
       - name: Run Tests for ${{ matrix.python-version }}
@@ -58,6 +64,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
       - name: Install dependencies
         run: |
           pip install -r docs/requirements.txt
@@ -69,7 +77,7 @@ jobs:
   pypi-release:
     needs: test-extension
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'refs/tags/') && github.repository_owner	== 'wpilibsuite'
+    if: contains(github.ref, 'refs/tags/') && github.repository_owner == 'wpilibsuite'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -78,6 +86,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+          cache: pip
+          cache-dependency-path: dev-requirements.txt
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,7 +22,40 @@ jobs:
         pip install black
         black --check --exclude /docs --diff .
 
+  build-wheel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+          cache: pip
+          cache-dependency-path: |
+            .github/workflows/workflow.yml
+            dev-requirements.txt
+      - name: Install dependencies
+        run: |
+          set -xe
+          python -VV
+          python -m site
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r dev-requirements.txt
+      - name: Install package
+        run: |
+          python -m pip install .
+      - name: Build wheel
+        run: |
+          python -m pip install build
+          python -m build
+      - name: Upload wheel as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: my-wheel
+          path: dist/*.whl
+
   test-extension:
+    needs: build-wheel
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -47,10 +80,15 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r dev-requirements.txt
           python -m pip install "sphinx${{ matrix.sphinx-version }}"
-      - name: Install package
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: my-wheel
+          path: dist
+      - name: Install downloaded wheel
         run: |
-          python -m pip install .
-      - name: Run Tests for ${{ matrix.python-version }}
+          python -m pip install dist/sphinxext_opengraph-main-py3-none-any.whl
+      - name: Run tests for ${{ matrix.python-version }}
         run: |
           python -m pytest -vv
 
@@ -88,14 +126,11 @@ jobs:
           python-version: '3.x'
           cache: pip
           cache-dependency-path: dev-requirements.txt
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r ./dev-requirements.txt
-      - name: Build PyPI Wheel
-        run: |
-          python setup.py sdist
-          python setup.py bdist_wheel
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: my-wheel
+          path: dist
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
-        sphinx-version: ['>=2,<3', '>=3,<4', '>=4,<5', '>=5,<6', '==6.0.0b1']
+        sphinx-version: ['>=4,<5', '>=5,<6', '==6.0.0b1']
         exclude:
           - { python-version: '3.7', sphinx-version: '==6.0.0b1' } # Sphinx 6 supports 3.8+
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,8 +13,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Black
@@ -28,9 +28,9 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7',  '3.8', '3.9', 'pypy3']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -50,11 +50,11 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
       - name: Install dependencies
         run: |
           pip install -r docs/requirements.txt
@@ -68,11 +68,11 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'refs/tags/') && github.repository_owner	== 'wpilibsuite'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.7'
       - name: Install Dependencies

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.x'
     - name: Black
       run: |
         pip install black
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7',  '3.8', '3.9', 'pypy3.8']
+        python-version: ['3.6', '3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.x'
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,11 +1,9 @@
 name: Test and Deploy
 on:
   pull_request:
-    branches: 
-      - main
-  push:
     branches:
       - main
+  push:
   create:
     tags:
       - '*'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,6 +25,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
+        sphinx-version: ['>=2,<3', '>=3,<4', '>=4,<5', '>=5,<6', '==6.0.0b1']
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -38,6 +39,7 @@ jobs:
           python -m site
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r dev-requirements.txt
+          python -m pip install "sphinx${{ matrix.sphinx-version }}"
       - name: Install Package
         run: |
           python -m pip install .
@@ -53,6 +55,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
       - name: Install dependencies
         run: |
           pip install -r docs/requirements.txt

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -61,13 +61,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
-        sphinx-version: ['>=4,<5', '>=5,<6', '==6.0.0b1']
+        sphinx-version: ['>=4,<5', '>=5,<6', '>=6a0,<7']
         os: [windows-latest, macos-latest, ubuntu-latest]
         exclude:
           # Sphinx 6 supports 3.8+
-          - { python-version: '3.7', sphinx-version: '==6.0.0b1', os: windows-latest }
-          - { python-version: '3.7', sphinx-version: '==6.0.0b1', os: macos-latest }
-          - { python-version: '3.7', sphinx-version: '==6.0.0b1', os: ubuntu-latest }
+          - { python-version: '3.7', sphinx-version: '>=6a0,<7' }
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
+        python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -56,14 +56,18 @@ jobs:
 
   test-extension:
     needs: build-wheel
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
         sphinx-version: ['>=4,<5', '>=5,<6', '==6.0.0b1']
+        os: [windows-latest, macos-latest, ubuntu-latest]
         exclude:
-          - { python-version: '3.7', sphinx-version: '==6.0.0b1' } # Sphinx 6 supports 3.8+
+          # Sphinx 6 supports 3.8+
+          - { python-version: '3.7', sphinx-version: '==6.0.0b1', os: windows-latest }
+          - { python-version: '3.7', sphinx-version: '==6.0.0b1', os: macos-latest }
+          - { python-version: '3.7', sphinx-version: '==6.0.0b1', os: ubuntu-latest }
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -76,7 +80,6 @@ jobs:
             dev-requirements.txt
       - name: Install dependencies
         run: |
-          set -xe
           python -VV
           python -m site
           python -m pip install --upgrade pip setuptools wheel

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 sphinx
-wheel==0.34.2
-pytest==5.4.3
-beautifulsoup4==4.9.1
-setuptools==47.3.1
+wheel==0.37.1
+pytest==7.0.1 # 7.0.1 is the last to support EOL Python 3.6
+beautifulsoup4==4.11.1
+setuptools==59.6.0 # 59.6.0 is the last to support EOL Python 3.6

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 sphinx
 wheel==0.37.1
-pytest==7.0.1 # 7.0.1 is the last to support EOL Python 3.6
+pytest==7.1.3
 beautifulsoup4==4.11.1
-setuptools==59.6.0 # 59.6.0 is the last to support EOL Python 3.6
+setuptools==65.4.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-myst-parser==0.15.2
-furo==2021.11.12.1
-sphinx==4.2.0
+myst-parser==0.18.1
+furo==2022.9.29
+sphinx==5.2.3
 ./

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -53,5 +52,5 @@ setuptools.setup(
         "Topic :: Text Processing",
         "Topic :: Utilities",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/wpilibsuite/sphinxext-opengraph",
     license="LICENSE.md",
-    install_requires=["sphinx>=2.0"],
+    install_requires=["sphinx>=4.0"],
     packages=["sphinxext/opengraph"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python",
         "Topic :: Documentation :: Sphinx",
         "Topic :: Documentation",

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,7 @@ import setuptools
 try:
     ret = subprocess.run(
         "git describe --tags --abbrev=0",
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=True,
         shell=True,
     )
@@ -16,7 +15,7 @@ try:
 except:
     version = "main"
 
-with open("README.md", "r", encoding="utf-8") as readme:
+with open("README.md", encoding="utf-8") as readme:
     long_description = readme.read()
 
 setuptools.setup(

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -72,7 +72,7 @@ def get_tags(
         parse_result = urlparse(config["html_baseurl"])
 
         if config["html_baseurl"] is None:
-            raise EnvironmentError("ReadTheDocs did not provide a valid canonical URL!")
+            raise OSError("ReadTheDocs did not provide a valid canonical URL!")
 
         # Grab root url from canonical url
         config["ogp_site_url"] = urlunparse(

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -4,7 +4,7 @@ import conftest
 
 
 def get_tag(tags, tag_type):
-    return [tag for tag in tags if tag.get("property") == "og:{}".format(tag_type)][0]
+    return [tag for tag in tags if tag.get("property") == f"og:{tag_type}"][0]
 
 
 def get_tag_content(tags, tag_type):


### PR DESCRIPTION
Fixes https://github.com/wpilibsuite/sphinxext-opengraph/issues/36.

Includes PR https://github.com/wpilibsuite/sphinxext-opengraph/pull/67 to avoid conflicts.

---

https://github.com/wpilibsuite/sphinxext-opengraph/issues/36#issuecomment-769327008 says:

> We should test on all platforms.
> 
> The workflow should be:
> 
> 1. ubuntu python3.6 builds the wheel and uploads it as an artifact
> 2. [win, mac, ubuntu] x [py 3.6, 3.7, 3.8, 3.9] download and test the wheel
> 3. ubuntu uploads the wheel

So let's do this, except using Python 3.7 instead of removed EOL 3.6, and testing the wheel on 3.7-3.11.

* Was there a particular reason 3.6 was suggested for building the wheel? Should we use a newer one like 3.10?

---

Further, https://github.com/wpilibsuite/sphinxext-opengraph/issues/36#issuecomment-769425328 says:

> We should also test on major supported sphinx versions

So let's also test on Sphinx 4, 5 and [6 beta](https://github.com/sphinx-doc/sphinx/issues/10920). 

* I did try Sphinx 2 and 3 as well but they [failed due to incompatibilities of Sphinx dependencies](https://github.com/hugovk/sphinxext-opengraph/actions/runs/3263192265), and it's probably not worth supporting such old versions. It would make the matrix even bigger than the current 51(!) jobs and be more complex as they don't support 3.10+ either.

* The matrix could be reduced by only testing oldest and newest Python stable versions, plus RC + PyPy (i.e. 3.7, 3.10, 3.11-dev, pypy3.8)

---

<img width="977" alt="image" src="https://user-images.githubusercontent.com/1324225/196142354-b88b8dd8-6c6d-4cfc-962b-e4d55985cc04.png">

https://github.com/hugovk/sphinxext-opengraph/actions/runs/3263561876