### PR TITLE
Add option to use og:description as description

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,8 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+# Generate <meta name="description" content="..."> tags.
+enable_meta_description = True
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -28,10 +28,10 @@ IMAGE_MIME_TYPES = {
 }
 
 
-def make_tag(property: str, content: str) -> str:
+def make_tag(property: str, content: str, type_: str = "property") -> str:
     # Parse quotation, so they won't break html tags if smart quotes are disabled
     content = content.replace('"', "&quot;")
-    return f'<meta property="{property}" content="{content}" />\n  '
+    return f'<meta {type_}="{property}" content="{content}" />\n  '
 
 
 def get_tags(
@@ -104,6 +104,10 @@ def get_tags(
     # description tag
     if description:
         tags["og:description"] = description
+        if config["enable_meta_description"]:
+            config["ogp_custom_meta_tags"].append(
+                make_tag("description", description, "name")
+            )
 
     # image tag
     # Get basic values from config
@@ -183,6 +187,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("ogp_type", "website", "html")
     app.add_config_value("ogp_site_name", None, "html")
     app.add_config_value("ogp_custom_meta_tags", [], "html")
+    app.add_config_value("enable_meta_description", False, "html")
 
     app.connect("html-page-context", html_page_context)
 

--- a/tests/roots/test-meta-name-description/conf.py
+++ b/tests/roots/test-meta-name-description/conf.py
@@ -1,0 +1,10 @@
+extensions = ["sphinxext.opengraph"]
+
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+html_theme = "basic"
+
+ogp_site_url = "http://example.org/en/latest/"
+
+enable_meta_description = True

--- a/tests/roots/test-meta-name-description/index.rst
+++ b/tests/roots/test-meta-name-description/index.rst
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,7 +1,6 @@
 import pytest
 from sphinx.application import Sphinx
 import conftest
-import os
 
 
 def get_tag(tags, tag_type):
@@ -24,6 +23,16 @@ def test_simple(og_meta_tags):
         description
         == "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci vari..."
     )
+
+
+@pytest.mark.sphinx("html", testroot="meta-name-description")
+def test_meta_name_description(meta_tags):
+    og_description = get_tag_content(meta_tags, "description")
+    description = [tag for tag in meta_tags if tag.get("name") == "description"][0].get(
+        "content", ""
+    )
+
+    assert og_description == description
 
 
 @pytest.mark.sphinx("html", testroot="simple")


### PR DESCRIPTION
For https://github.com/wpilibsuite/sphinxext-opengraph/issues/65.

Adds a Boolean option for `conf.py` called `enable_meta_description`, which when true, will add the same description to `<meta name="description" content="...">` as used for `<meta property="og:description" content="...">`.

We're looking into using this extension in the CPython docs (for example: [official docs](https://docs.python.org/), [devguide](https://devguide.python.org/), [PEPs](https://peps.python.org/)), and improving the SEO by adding the meta description would be very helpful.

Re: https://github.com/python/docs-community/issues/65

