### PR TITLE
Create wheel with version number not "main"

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,6 +7,10 @@ on:
   create:
     tags:
       - '*'
+
+env:
+  FORCE_COLOR: 1
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -101,7 +101,7 @@ jobs:
           path: dist
       - name: Install downloaded wheel
         run: |
-          python -m pip install --find-links=dist sphinxext-opengraph
+          python -m pip install --no-index --find-links=dist sphinxext-opengraph
       - name: Run tests for ${{ matrix.python-version }}
         run: |
           python -m pytest -vv

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -101,7 +101,7 @@ jobs:
           path: dist
       - name: Install downloaded wheel
         run: |
-          python -m pip install dist/sphinxext_opengraph-main-py3-none-any.whl
+          python -m pip install --find-links=dist sphinxext-opengraph
       - name: Run tests for ${{ matrix.python-version }}
         run: |
           python -m pytest -vv

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -65,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11-dev', 'pypy3.8']
+        python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11', 'pypy3.8']
         sphinx-version: ['>=4,<5', '>=5,<6', '>=6a0,<7']
         os: [windows-latest, macos-latest, ubuntu-latest]
         exclude:

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,12 @@
-import subprocess
-
 import setuptools
-
-# This will fail if something happens or if not in a git repository.
-# This is intentional.
-try:
-    ret = subprocess.run(
-        "git describe --tags --abbrev=0",
-        capture_output=True,
-        check=True,
-        shell=True,
-    )
-    version = ret.stdout.decode("utf-8").strip()
-except:
-    version = "main"
 
 with open("README.md", encoding="utf-8") as readme:
     long_description = readme.read()
 
 setuptools.setup(
     name="sphinxext-opengraph",
-    version=version,
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
     author="Itay Ziv",
     author_email="itay220204@gmail.com",
     description="Sphinx Extension to enable OGP support",


### PR DESCRIPTION
Fixes part two of https://github.com/wpilibsuite/sphinxext-opengraph/issues/76.

Fetch all tags:

https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches

So that when `setup.py` runs:

https://github.com/wpilibsuite/sphinxext-opengraph/blob/a2d9acc031510cdc6e9e274f16d1efe27d5849aa/setup.py#L5-L16

We use the version in the wheel name and not `"main"`.
