### PR TITLE
Also publish sdist to PyPI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -56,11 +56,11 @@ jobs:
         run: |
           python -m pip install build
           python -m build
-      - name: Upload wheel as artifact
+      - name: Upload sdist and wheel artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: my-wheel
-          path: dist/*.whl
+          name: my-dist
+          path: dist/*
 
   test:
     needs: build-wheel
@@ -91,14 +91,14 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r dev-requirements.txt
           python -m pip install "sphinx${{ matrix.sphinx-version }}"
-      - name: Download wheel artifact
+      - name: Download sdist and wheel artifacts
         uses: actions/download-artifact@v3
         with:
-          name: my-wheel
+          name: my-dist
           path: dist
       - name: Install downloaded wheel
         run: |
-          python -m pip install --no-index --find-links=dist sphinxext-opengraph
+          python -m pip install --only-binary=:all: --no-index --find-links=dist sphinxext-opengraph
       - name: Run tests for ${{ matrix.python-version }}
         run: |
           python -m pytest -vv
@@ -128,10 +128,10 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'refs/tags/') && github.repository_owner == 'wpilibsuite'
     steps:
-      - name: Download wheel artifact
+      - name: Download sdist and wheel artifacts
         uses: actions/download-artifact@v3
         with:
-          name: my-wheel
+          name: my-dist
           path: dist
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This should fix https://github.com/wpilibsuite/sphinxext-opengraph/issues/81.

Before https://github.com/wpilibsuite/sphinxext-opengraph/pull/70, we built both the sdist and wheel before uploading to PyPI.

After https://github.com/wpilibsuite/sphinxext-opengraph/pull/70, we built them at the start, uploaded just the wheel as an artifact, then downloaded the wheel for testing, and downloaded the wheel for publishing to PyPI. But no sdist for publishing.

We can fix this by uploading both sdist and wheel as artifact, ensuring we only install the wheel using `--only-binary=:all:`, and then for PyPI publishing we also have both files.

(Another way would be to rebuild both in the `pypi-release` instead of using the artifact.)