### PR TITLE
Take default og:site_name from sphinx `project` config value

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Users hosting documentation on Read The Docs *do not* need to set any of the fol
 * `ogp_description_length`
     * Configure the amount of characters taken from a page. The default of 200 is probably good for most people. If something other than a number is used, it defaults back to 200. 
 * `ogp_site_name`
-    * This is not required. Name of the site. This is displayed above the title.
+    * This is not required. Name of the site. This is displayed above the title.  Taken from the Sphinx `project` config value if not given.
 * `ogp_image`
     * This is not required. Link to image to show. Note that all relative paths are converted to be relative to the root of the html output as defined by `ogp_site_url`.
 * `ogp_image_alt`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Users hosting documentation on Read The Docs *do not* need to set any of the fol
 * `ogp_description_length`
     * Configure the amount of characters taken from a page. The default of 200 is probably good for most people. If something other than a number is used, it defaults back to 200. 
 * `ogp_site_name`
-    * This is not required. Name of the site. This is displayed above the title.  Taken from the Sphinx `project` config value if not given.
+    * This is not required. Name of the site. This is displayed above the title. Defaults to the Sphinx `project` config value.
 * `ogp_image`
     * This is not required. Link to image to show. Note that all relative paths are converted to be relative to the root of the html output as defined by `ogp_site_url`.
 * `ogp_image_alt`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Users hosting documentation on Read The Docs *do not* need to set any of the fol
 * `ogp_description_length`
     * Configure the amount of characters taken from a page. The default of 200 is probably good for most people. If something other than a number is used, it defaults back to 200. 
 * `ogp_site_name`
-    * This is not required. Name of the site. This is displayed above the title. Defaults to the Sphinx `project` config value.
+    * This is not required. Name of the site. This is displayed above the title. Defaults to the Sphinx [`project`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-project) config value.  Set to `False` to unset and use no default.
 * `ogp_image`
     * This is not required. Link to image to show. Note that all relative paths are converted to be relative to the root of the html output as defined by `ogp_site_url`.
 * `ogp_image_alt`

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -108,6 +108,9 @@ def get_tags(
     site_name = config["ogp_site_name"]
     if site_name:
         tags["og:site_name"] = site_name
+    elif config["project"]:
+        site_name = config["project"]
+        tags["og:site_name"] = config["project"]
 
     # description tag
     if description:

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -104,13 +104,16 @@ def get_tags(
         )
     tags["og:url"] = page_url
 
-    # site name tag
-    site_name = config["ogp_site_name"]
+    # site name tag, False disables, default to project if ogp_site_name not
+    # set.
+    if config["ogp_site_name"] is False:
+        site_name = None
+    elif config["ogp_site_name"] is None:
+        site_name = config["project"]
+    else:
+        site_name = config["ogp_site_name"]
     if site_name:
         tags["og:site_name"] = site_name
-    elif config["project"]:
-        site_name = config["project"]
-        tags["og:site_name"] = config["project"]
 
     # description tag
     if description:

--- a/tests/roots/test-sitename-from-project/conf.py
+++ b/tests/roots/test-sitename-from-project/conf.py
@@ -1,0 +1,11 @@
+
+extensions = ["sphinxext.opengraph"]
+
+project = "Project name"
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+html_theme = "basic"
+
+ogp_site_url = "http://example.org/en/latest/"
+

--- a/tests/roots/test-sitename-from-project/conf.py
+++ b/tests/roots/test-sitename-from-project/conf.py
@@ -1,4 +1,3 @@
-
 extensions = ["sphinxext.opengraph"]
 
 project = "Project name"
@@ -8,4 +7,3 @@ exclude_patterns = ["_build"]
 html_theme = "basic"
 
 ogp_site_url = "http://example.org/en/latest/"
-

--- a/tests/roots/test-sitename-from-project/index.rst
+++ b/tests/roots/test-sitename-from-project/index.rst
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -106,6 +106,10 @@ def test_description_length(og_meta_tags):
 def test_site_name(og_meta_tags):
     assert get_tag_content(og_meta_tags, "site_name") == "Example's Docs!"
 
+@pytest.mark.sphinx("html", testroot="sitename-from-project")
+def test_site_name_project(og_meta_tags):
+    assert get_tag_content(og_meta_tags, "site_name") == "Project name"
+
 
 @pytest.mark.sphinx("html", testroot="first-image")
 def test_first_image(og_meta_tags):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -106,6 +106,7 @@ def test_description_length(og_meta_tags):
 def test_site_name(og_meta_tags):
     assert get_tag_content(og_meta_tags, "site_name") == "Example's Docs!"
 
+
 @pytest.mark.sphinx("html", testroot="sitename-from-project")
 def test_site_name_project(og_meta_tags):
     assert get_tag_content(og_meta_tags, "site_name") == "Project name"


### PR DESCRIPTION
- The standard `project` Sphinx config value seems like a reasonable
  default value for the site_name.
- This uses that as a default, if `ogp_site_name` is not set.
- This will change the default, and add `og:site_name` for many
  projects where it previously wasn't set.

Perhaps I should have asked before doing this, since the last point
may be a blocker.  But it was easier to do than think too much...
