### PR TITLE
Allow dirhtml builder without `ogp_site_url`

### DIFF
--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -193,7 +193,9 @@ def html_page_context(
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:
-    app.add_config_value("ogp_site_url", None, "html")
+    # ogp_site_url="" allows relative by default, even though it's not
+    # officially supported by OGP.
+    app.add_config_value("ogp_site_url", "", "html")
     app.add_config_value("ogp_description_length", DEFAULT_DESCRIPTION_LENGTH, "html")
     app.add_config_value("ogp_image", None, "html")
     app.add_config_value("ogp_image_alt", None, "html")

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -69,7 +69,7 @@ def get_tags(
     # type tag
     tags["og:type"] = config["ogp_type"]
 
-    if os.getenv("READTHEDOCS") and config["ogp_site_url"] is None:
+    if os.getenv("READTHEDOCS") and not config["ogp_site_url"]:
         # readthedocs uses html_baseurl for sphinx > 1.8
         parse_result = urlparse(config["html_baseurl"])
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -279,3 +279,17 @@ def test_rtd_invalid(app: Sphinx, monkeypatch):
 
     with pytest.raises(Exception):
         app.build()
+
+
+# Test no breakage with no configuration
+@pytest.mark.sphinx("html", testroot="no-configuration")
+def test_no_configuration_html(og_meta_tags):
+    print(og_meta_tags)
+    assert get_tag_content(og_meta_tags, "type") == "website"
+
+
+# Test no breakage with no configuration
+@pytest.mark.sphinx("dirhtml", testroot="no-configuration")
+def test_no_configuration_dirhtml(og_meta_tags):
+    print(og_meta_tags)
+    assert get_tag_content(og_meta_tags, "type") == "website"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -284,12 +284,10 @@ def test_rtd_invalid(app: Sphinx, monkeypatch):
 # Test no breakage with no configuration
 @pytest.mark.sphinx("html", testroot="no-configuration")
 def test_no_configuration_html(og_meta_tags):
-    print(og_meta_tags)
     assert get_tag_content(og_meta_tags, "type") == "website"
 
 
 # Test no breakage with no configuration
 @pytest.mark.sphinx("dirhtml", testroot="no-configuration")
 def test_no_configuration_dirhtml(og_meta_tags):
-    print(og_meta_tags)
     assert get_tag_content(og_meta_tags, "type") == "website"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -282,12 +282,12 @@ def test_rtd_invalid(app: Sphinx, monkeypatch):
 
 
 # Test no breakage with no configuration
-@pytest.mark.sphinx("html", testroot="no-configuration")
+@pytest.mark.sphinx("html", testroot="rtd-default")
 def test_no_configuration_html(og_meta_tags):
     assert get_tag_content(og_meta_tags, "type") == "website"
 
 
 # Test no breakage with no configuration
-@pytest.mark.sphinx("dirhtml", testroot="no-configuration")
+@pytest.mark.sphinx("dirhtml", testroot="rtd-default")
 def test_no_configuration_dirhtml(og_meta_tags):
     assert get_tag_content(og_meta_tags, "type") == "website"


### PR DESCRIPTION
- Yes, the readme says that ogp_site_url is very important.  And
  indeed, reports online say that OGP doesn't work with relative URLs.
  Although at least one place says it does...
- Yet, I got confused when I could build it with html (it left
  everything relative), but not with dirhtml (obscure extension error
  it took me a while to figure out).  (And it only fails on the page
  named `/index`.
- I tried several different things, like first adding an exception
  when ogp_site_url is unset.  But then I realized what the root issue
  was, and thought that something less invasive, keeping existing
  behavior, even if it wasn't perfect.  Then we can see where to go
  from there.
- Even if this isn't perfect, it helps a bit with "make this extension
  do something useful, even if not perfect, if it's installed but not
  configured".
- This change makes `/index` work with dirhtml without any
  configuration, since `urljoin` works with `None` as a first argument
  to leave the URLs as relative.  This seemed like the the most
  consistent and least invasive change.
- So overall, even though this isn't a perfect change, and could be
  considered technically incorrect, I think it's less confusing and
  makes things more consistent for a possibly better solution later.
