### PR TITLE
Add `:ogp_disable:` metadata field

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Make sure you place the fields at the very start of the document such that Sphin
 These are some overrides that can be used on individual pages, you can actually override any tag and field lists will always take priority.
 
 * `:ogp_description_length:`
-  * Configure the amount of characters to grab for the description of the page. If the value isn't a number it will fall back to `ogp_description_length`. Note the slightly different syntax because this isn't directly an Open Graph tag.
+  * Configure the amount of characters to grab for the description of the page. If the value isn't a number it will fall back to `ogp_description_length`.[^2]
+* `:ogp_disable:`
+  * Disables all Open Graph tags on the page.[^2]
 * `:og:description:`
   * Lets you override the description of the page.
 * `:description:` or `.. meta::\n :description:`
@@ -113,3 +115,4 @@ Page contents
 ```
 
 [^1]: Note: Relative file paths for images, videos and audio are currently **not** supported when using field lists. Please use an absolute path instead.
+[^2]: Note the slightly different syntax because this isn't directly an Open Graph tag.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ These are some overrides that can be used on individual pages, you can actually 
 * `:ogp_description_length:`
   * Configure the amount of characters to grab for the description of the page. If the value isn't a number it will fall back to `ogp_description_length`.[^1]
 * `:ogp_disable:`
-  * Disables all Open Graph tags on the page.[^1]
+  * Disables generation of Open Graph tags on the page.[^1]
 * `:og:description:`
   * Lets you override the description of the page.
 * `:description:` or `.. meta::\n :description:`

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Make sure you place the fields at the very start of the document such that Sphin
 These are some overrides that can be used on individual pages, you can actually override any tag and field lists will always take priority.
 
 * `:ogp_description_length:`
-  * Configure the amount of characters to grab for the description of the page. If the value isn't a number it will fall back to `ogp_description_length`.[^2]
+  * Configure the amount of characters to grab for the description of the page. If the value isn't a number it will fall back to `ogp_description_length`.[^1]
 * `:ogp_disable:`
-  * Disables all Open Graph tags on the page.[^2]
+  * Disables all Open Graph tags on the page.[^1]
 * `:og:description:`
   * Lets you override the description of the page.
 * `:description:` or `.. meta::\n :description:`
@@ -88,7 +88,7 @@ These are some overrides that can be used on individual pages, you can actually 
 * `:og:type:`
   * Override the type of the page, for the list of available types take a look at https://ogp.me/#types.
 * `:og:image:`
-  * Set the image for the page.[^1]
+  * Set the image for the page.[^2]
 * `:og:image:alt:`
   * Sets the alt text. Will be ignored if there is no image set.
 
@@ -104,7 +104,7 @@ Page contents
 =============
 ```
 
-### Arbitrary Tags[^1]
+### Arbitrary Tags[^2]
 Additionally, you can use field lists to add any arbitrary Open Graph tag not supported by the extension. The syntax for arbitrary tags is the same with `:og:tag: content`. For example:
 
 ```rst
@@ -114,5 +114,5 @@ Page contents
 =============
 ```
 
-[^1]: Note: Relative file paths for images, videos and audio are currently **not** supported when using field lists. Please use an absolute path instead.
-[^2]: Note the slightly different syntax because this isn't directly an Open Graph tag.
+[^1]: Note the slightly different syntax because this isn't directly an Open Graph tag.
+[^2]: Note: Relative file paths for images, videos and audio are currently **not** supported when using field lists. Please use an absolute path instead.

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -45,6 +45,10 @@ def get_tags(
     fields = context["meta"]
     if fields is None:
         fields = {}
+
+    if "ogp_disable" in fields:
+        return ""
+
     tags = {}
     meta_tags = {}  # For non-og meta tags
 

--- a/tests/roots/test-overrides-disable/conf.py
+++ b/tests/roots/test-overrides-disable/conf.py
@@ -1,0 +1,11 @@
+extensions = ["sphinxext.opengraph"]
+
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+html_theme = "basic"
+
+ogp_site_name = "Example's Docs!"
+ogp_site_url = "http://example.org/en/latest/"
+ogp_image = "http://example.org/en/latest/image.png"
+ogp_type = "book"

--- a/tests/roots/test-overrides-disable/index.rst
+++ b/tests/roots/test-overrides-disable/index.rst
@@ -1,0 +1,5 @@
+:ogp_disable:
+
+Lorem Ipsum
+===========
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -239,6 +239,11 @@ def test_overrides_complex(og_meta_tags):
     assert get_tag_content(og_meta_tags, "image:alt") == "Overridden Alt Text"
 
 
+@pytest.mark.sphinx("html", testroot="overrides-disable")
+def test_overrides_disable(og_meta_tags):
+    assert len(og_meta_tags) == 0
+
+
 @pytest.mark.sphinx("html", testroot="arbitrary-tags")
 def test_arbitrary_tags(og_meta_tags):
     assert (


### PR DESCRIPTION
Adds a way of disabling opengraph tags per-page using an `:ogp_disable:` field.

We've had a need for something like this on things like API reference pages, which don't necessarily have a proper description and/or shouldn't have og tags for other reasons.
This is more of a proposal and I'd understand if you don't want to add something like this, but it would be a step up from our current, somewhat hacky solution of hooking into the `html-page-context` callback :)