### PR TITLE
Use Sphinx Builder method to get page url

### DIFF
--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -90,18 +90,9 @@ def get_tags(
 
     # url tag
     # Get the URL of the specific page
-    if context["builder"] == "dirhtml":
-        if context["pagename"] == "index":
-            page_url = config["ogp_site_url"]
-        elif context["pagename"].endswith("/index"):
-            relative = context["pagename"].rsplit("/", 1)[0]
-            page_url = urljoin(config["ogp_site_url"], relative + "/")
-        else:
-            page_url = urljoin(config["ogp_site_url"], context["pagename"] + "/")
-    else:
-        page_url = urljoin(
-            config["ogp_site_url"], context["pagename"] + context["file_suffix"]
-        )
+    page_url = urljoin(
+        config["ogp_site_url"], app.builder.get_target_uri(context["pagename"])
+    )
     tags["og:url"] = page_url
 
     # site name tag, False disables, default to project if ogp_site_name not


### PR DESCRIPTION
## Overview

This PR is to generate `og:url` correctly for other dirhtml-based builders.

## Details

I develop [sphinx-revealjs](https://github.com/attakei/sphinx-revealjs/) (Sphinx extension to generate presentation) that have `dirrevealjs` builder extended `dirhtml`.
I am adding opengraph metatags for `dirrevealjs` outputs using `sphinxext-opengraph`, but it does not work for expected.

This has generated `/index.html` for `og:url` when use `dirrevealjs` builder.
But, this should generate `/` ended.
(For reproduction, please see [my reproduction demo](https://github.com/attakei-sandbox/dirrevealjs-with-opengraph).)

## For fix(about diff)

Currently, `get_tags` build page_url manually for `dirhtml`.
Sphinx builder class has `get_target_uri` for generate document url from pagename to ref page.
I hope to use this to build `og:url`.