### PR TITLE
check for description length before subscripting

### DIFF
--- a/sphinxext/opengraph/descriptionparser.py
+++ b/sphinxext/opengraph/descriptionparser.py
@@ -101,7 +101,7 @@ class DescriptionParser(nodes.NodeVisitor):
 
         # Separate end of list from text
         if isinstance(node, nodes.Sequential):
-            if self.description[-1] == ",":
+            if self.description and self.description[-1] == ",":
                 self.description = self.description[:-1]
             self.description += "."
             self.list_level -= 1


### PR DESCRIPTION
This is getting triggered sporadically by the top-translator page in frc-docs. I think top-translator might occasionally be creating a bad doctree that hits this. I haven't been able to make a test file for this as I think the rst -> doctree parser does things correctly.