### PR TITLE
Format with Black 23.1.0

### DIFF
--- a/sphinxext/opengraph/descriptionparser.py
+++ b/sphinxext/opengraph/descriptionparser.py
@@ -15,7 +15,6 @@ class DescriptionParser(nodes.NodeVisitor):
         known_titles: Iterable[str] = None,
         document: nodes.document = None,
     ):
-
         # Hack to prevent requirement for the doctree to be passed in.
         # It's only used by doctree.walk(...) to print debug messages.
         if document is None:
@@ -43,7 +42,6 @@ class DescriptionParser(nodes.NodeVisitor):
         self.stop = False
 
     def dispatch_visit(self, node: nodes.Element) -> None:
-
         if self.stop:
             raise nodes.StopTraversal
 
@@ -90,7 +88,6 @@ class DescriptionParser(nodes.NodeVisitor):
             self.description += text
 
     def dispatch_departure(self, node: nodes.Element) -> None:
-
         # Separate title from text
         if isinstance(node, nodes.title):
             self.description += ":"
@@ -121,7 +118,6 @@ def get_description(
     known_titles: Iterable[str] = None,
     document: nodes.document = None,
 ):
-
     mcv = DescriptionParser(description_length, known_titles, document)
     doctree.walkabout(mcv)
     return mcv.description


### PR DESCRIPTION
Black 23.1.0 has been released with a new stable style for 2023:

* https://github.com/psf/black/releases/tag/23.1.0
* https://ichard26.github.io/blog/2023/01/black-23.1.0/

This formats the code with the new version, which fixes the check on the CI.

Before: https://github.com/hugovk/sphinxext-opengraph/actions/runs/4062858491/jobs/6994400880

After: https://github.com/hugovk/sphinxext-opengraph/actions/runs/4062869689/jobs/6994425004
