### PR TITLE
Add exception for SVG images

### DIFF
--- a/docs/source/socialcards.md
+++ b/docs/source/socialcards.md
@@ -23,13 +23,31 @@ ogp_social_cards = {
 }
 ```
 
+## Update the top-right image
+
+By default the top-right image will use the image specified by `html_logo` if it exists.
+To update it, specify another path in the **`image`** key like so:
+
+```{code-block} python
+:caption: conf.py
+
+ogp_social_cards = {
+    "image": "path/to/image.png",
+}
+```
+
+```{admonition} The image cannot be an SVG
+:class: warning
+
+Matplotlib does not support easy plotting of SVG images, so ensure that your image is a PNG or JPEG file, not SVG.
+```
+
 ## Customize the card
 
 There are several customization options to change the text and look of the social media preview card.
 Below is a summary of these options.
 
 - **`site_url`**: Set a custom site URL.
-- **`image`**: Over-ride the top-right image (by default, `html_logo` is used).
 - **`line_color`**: Color of the border line at the bottom of the card, in hex format.
 % TODO: add an over-ride for each part of the card.
 

--- a/sphinxext/opengraph/socialcards.py
+++ b/sphinxext/opengraph/socialcards.py
@@ -102,7 +102,7 @@ def create_social_card(
             kwargs_fig[img] = None
         
         # If image doesn't exist, throw a warning and replace with none
-        if not img.exists():
+        if not impath.exists():
             LOGGER.warn(f"[Social card]: {img} file doesn't exist, skipping...")
             kwargs_fig[img] = None
 

--- a/sphinxext/opengraph/socialcards.py
+++ b/sphinxext/opengraph/socialcards.py
@@ -265,12 +265,12 @@ def create_social_card_objects(
             c=site_url_color,
         )
 
-    if image_mini and not str(image_mini).endswith("svg"):
+    if image_mini and not str(image_mini).lower().endswith("svg"):
         img = mpimg.imread(image_mini)
         axim_mini.imshow(img)
 
     # Put the logo in the top right if it exists
-    if image and not str(image).endswith("svg"):
+    if image and not str(image).lower().endswith("svg"):
         img = mpimg.imread(image)
         yw, xw = img.shape[:2]
 

--- a/sphinxext/opengraph/socialcards.py
+++ b/sphinxext/opengraph/socialcards.py
@@ -270,7 +270,7 @@ def create_social_card_objects(
         axim_mini.imshow(img)
 
     # Put the logo in the top right if it exists
-    if image:
+    if image and not image.endswith("svg"):
         img = mpimg.imread(image)
         yw, xw = img.shape[:2]
 

--- a/sphinxext/opengraph/socialcards.py
+++ b/sphinxext/opengraph/socialcards.py
@@ -95,12 +95,12 @@ def create_social_card(
     # Validation on the images
     for img in ["image_mini", "image"]:
         impath = kwargs_fig.get(img)
-        
+
         # If image is an SVG replace it with None
         if impath.suffix.lower() == ".svg":
             LOGGER.warn(f"[Social card] {img} cannot be an SVG image, skipping...")
             kwargs_fig[img] = None
-        
+
         # If image doesn't exist, throw a warning and replace with none
         if not impath.exists():
             LOGGER.warn(f"[Social card]: {img} file doesn't exist, skipping...")

--- a/sphinxext/opengraph/socialcards.py
+++ b/sphinxext/opengraph/socialcards.py
@@ -265,7 +265,7 @@ def create_social_card_objects(
             c=site_url_color,
         )
 
-    if image_mini:
+    if image_mini and not str(image_mini).endswith("svg"):
         img = mpimg.imread(image_mini)
         axim_mini.imshow(img)
 

--- a/sphinxext/opengraph/socialcards.py
+++ b/sphinxext/opengraph/socialcards.py
@@ -95,6 +95,8 @@ def create_social_card(
     # Validation on the images
     for img in ["image_mini", "image"]:
         impath = kwargs_fig.get(img)
+        if not impath:
+            continue
 
         # If image is an SVG replace it with None
         if impath.suffix.lower() == ".svg":

--- a/sphinxext/opengraph/socialcards.py
+++ b/sphinxext/opengraph/socialcards.py
@@ -270,7 +270,7 @@ def create_social_card_objects(
         axim_mini.imshow(img)
 
     # Put the logo in the top right if it exists
-    if image and not image.endswith("svg"):
+    if image and not str(image).endswith("svg"):
         img = mpimg.imread(image)
         yw, xw = img.shape[:2]
 

--- a/sphinxext/opengraph/socialcards.py
+++ b/sphinxext/opengraph/socialcards.py
@@ -4,10 +4,11 @@ from pathlib import Path
 import matplotlib
 from matplotlib import pyplot as plt
 import matplotlib.image as mpimg
+from sphinx.util import logging
 
 matplotlib.use("agg")
 
-
+LOGGER = logging.getLogger(__name__)
 HERE = Path(__file__).parent
 MAX_CHAR_PAGE_TITLE = 75
 MAX_CHAR_DESCRIPTION = 175
@@ -90,6 +91,20 @@ def create_social_card(
         kwargs_fig["image_mini"] = (
             Path(__file__).parent / "_static/sphinx-logo-shadow.png"
         )
+
+    # Validation on the images
+    for img in ["image_mini", "image"]:
+        impath = kwargs_fig.get(img)
+        
+        # If image is an SVG replace it with None
+        if impath.suffix.lower() == ".svg":
+            LOGGER.warn(f"[Social card] {img} cannot be an SVG image, skipping...")
+            kwargs_fig[img] = None
+        
+        # If image doesn't exist, throw a warning and replace with none
+        if not img.exists():
+            LOGGER.warn(f"[Social card]: {img} file doesn't exist, skipping...")
+            kwargs_fig[img] = None
 
     # These are passed directly from the user configuration to our plotting function
     pass_through_config = ["text_color", "line_color", "background_color", "font"]
@@ -265,12 +280,12 @@ def create_social_card_objects(
             c=site_url_color,
         )
 
-    if image_mini and not str(image_mini).lower().endswith("svg"):
+    if isinstance(image_mini, Path):
         img = mpimg.imread(image_mini)
         axim_mini.imshow(img)
 
     # Put the logo in the top right if it exists
-    if image and not str(image).lower().endswith("svg"):
+    if isinstance(image, Path):
         img = mpimg.imread(image)
         yw, xw = img.shape[:2]
 

--- a/tests/roots/test-social-cards-svg/conf.py
+++ b/tests/roots/test-social-cards-svg/conf.py
@@ -1,0 +1,12 @@
+extensions = ["sphinxext.opengraph"]
+
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+html_theme = "basic"
+ogp_site_url = "http://example.org/en/latest/"
+
+# The image is an SVG, and so it should not be included in the social cards
+ogp_social_cards = {
+    "image": "foo.svg",
+}

--- a/tests/roots/test-social-cards-svg/index.rst
+++ b/tests/roots/test-social-cards-svg/index.rst
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at lorem ornare, fringilla massa nec, venenatis mi. Donec erat sapien, tincidunt nec rhoncus nec, scelerisque id diam. Orci varius natoque penatibus et magnis dis parturient mauris.

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -87,6 +87,12 @@ def test_local_image(og_meta_tags):
     )
 
 
+@pytest.mark.sphinx("html", testroot="social-cards-svg")
+def test_social_cards_svg(app: Sphinx, og_meta_tags):
+    """If the social cards image is an SVG, it should not be in the social card."""
+    assert app.statuscode == 0
+
+
 @pytest.mark.sphinx("html", testroot="image")
 def test_image_alt(og_meta_tags):
     assert get_tag_content(og_meta_tags, "image:alt") == "Example's Docs!"


### PR DESCRIPTION
I think this is a minimal patch to avoid breaking when a user has an SVG image. Ideally we would catch this and raise a warning in Sphinx, but I wanted to show the minimal patch to avoid the bug if you wanna make a patch release. I likely don't have time to do a proper implementation w/ a warning and such (am expecting a baby any day now)


- resolves #96 