### PR TITLE
FIX: Social media twitter card tags

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,8 +19,8 @@ nox.options.reuse_existing_virtualenvs = True
 @nox.session
 def docs(session):
     """Build the documentation. Use `-- live` to build with a live server."""
-    session.install("-e", ".")
     session.install("-r", "docs/requirements.txt")
+    session.install("-e", ".")
     if "live" in session.posargs:
         session.install("ipython")
         session.install("sphinx-autobuild")
@@ -34,5 +34,6 @@ def docs(session):
 @nox.session
 def test(session):
     """Run the test suite."""
-    session.install(".")
+    session.install("-e", ".")
+    session.install("-r", "dev-requirements.txt")
     session.run(*(["pytest"] + session.posargs))

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -136,8 +136,6 @@ def get_tags(
     config_social = DEFAULT_SOCIAL_CONFIG.copy()
     social_card_user_options = app.config.ogp_social_cards or {}
     config_social.update(social_card_user_options)
-
-    # This will only be False if the user explicitly sets it
     if (
         not (image_url or ogp_use_first_image)
         and config_social.get("enable") is not False
@@ -185,6 +183,13 @@ def get_tags(
         image_path = str(image_path).replace(os.path.sep, "/").strip("/")
         image_url = f"{url}/{image_path}"
 
+        # If the social card objects have been added we add special metadata for them
+        # These are the dimensions *in pixels* of the card
+        # They were chosen by looking at the image pixel dimensions on disk
+        tags["og:image:width"] = "1146"
+        tags["og:image:height"] = "600"
+        meta_tags["twitter:card"] = "summary_large_image"
+
     fields.pop("og:image:alt", None)
 
     first_image = None
@@ -223,12 +228,6 @@ def get_tags(
             tags["og:image:alt"] = site_name
         elif ogp_image_alt is None and title:
             tags["og:image:alt"] = title
-
-        if "ogp_social_card_tags" in context:
-            # Add social media metadata if we've activated preview cards
-            tags["og:image:width"] = meta["width"]
-            tags["og:image:height"] = meta["height"]
-            meta_tags["twitter:card"] = "summary_large_image"
 
     # arbitrary tags and overrides
     tags.update({k: v for k, v in fields.items() if k.startswith("og:")})

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3,13 +3,13 @@ from sphinx.application import Sphinx
 import conftest
 
 
-def get_tag(tags, tag_type):
-    return [tag for tag in tags if tag.get("property") == f"og:{tag_type}"][0]
+def get_tag(tags, tag_type, kind="property", prefix="og"):
+    return [tag for tag in tags if tag.get(kind) == f"{prefix}:{tag_type}"][0]
 
 
-def get_tag_content(tags, tag_type):
+def get_tag_content(tags, tag_type, kind="property", prefix="og"):
     # Gets the content of a specific ogp tag
-    return get_tag(tags, tag_type).get("content", "")
+    return get_tag(tags, tag_type, kind, prefix).get("content", "")
 
 
 def get_meta_description(tags):
@@ -99,17 +99,21 @@ def test_image_alt(og_meta_tags):
 
 
 @pytest.mark.sphinx("html", testroot="simple")
-def test_image_social_cards(og_meta_tags):
+def test_image_social_cards(meta_tags):
     """Social cards should automatically be added if no og:image is given."""
     # Asserting `in` instead of `==` because of the hash that is generated
     assert (
         "http://example.org/en/latest/_images/social_previews/summary_index"
-        in get_tag_content(og_meta_tags, "image")
+        in get_tag_content(meta_tags, "image")
     )
     # Image alt text should be taken from page content.
     assert (
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        in get_tag_content(og_meta_tags, "image:alt")
+        in get_tag_content(meta_tags, "image:alt")
+    )
+    # Make sure the extra tags are in the HTML
+    assert "summary_large_image" in get_tag_content(
+        meta_tags, "card", kind="name", prefix="twitter"
     )
 
 


### PR DESCRIPTION
I caught a bug that we weren't testing for. The `summary_large_image` tag wasn't being properly inserted. This fixes that bug, and also adds a test for it.