### PR TITLE
Drop support for EOL Python 3.7

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: pip
           cache-dependency-path: |
             .github/workflows/workflow.yml
@@ -68,12 +68,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7',  '3.8', '3.9', '3.10', '3.11', 'pypy3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy3.8']
         sphinx-version: ['>=4,<5', '>=5,<6', '>=6a0,<7']
         os: [windows-latest, macos-latest, ubuntu-latest]
-        exclude:
-          # Sphinx 6 supports 3.8+
-          - { python-version: '3.7', sphinx-version: '>=6a0,<7' }
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -39,5 +38,5 @@ setuptools.setup(
         "Topic :: Text Processing",
         "Topic :: Utilities",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/
