### PR TITLE
test: fix deprecation warning about path by using suggested Pathlib

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from bs4 import BeautifulSoup
-from sphinx.testing.path import path
+from pathlib import Path
 
 from sphinx.application import Sphinx
 
@@ -10,7 +10,7 @@ pytest_plugins = "sphinx.testing.fixtures"
 
 @pytest.fixture(scope="session")
 def rootdir():
-    return path(__file__).parent.abspath() / "roots"
+    return Path(__file__).parent.absolute() / "roots"
 
 
 @pytest.fixture()


### PR DESCRIPTION
I saw the following deprecation warning when running the tests on local:

```shell
> pipx run nox -s test
nox > Running session test
nox > Re-using existing virtual environment at .nox/test.
nox > python -m pip install -e .
nox > python -m pip install -r dev-requirements.txt
nox > pytest
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.11.5, pytest-7.1.3, pluggy-1.3.0
rootdir: /Users/shuuji3/dev/sphinxext-opengraph
collected 37 items

tests/test_options.py ..........s..........................                                                                                                                 [100%]

================================================================================ warnings summary =================================================================================
tests/conftest.py:3
  /Users/shuuji3/dev/sphinxext-opengraph/tests/conftest.py:3: RemovedInSphinx90Warning: 'sphinx.testing.path' is deprecated. Use 'os.path' or 'pathlib' instead.
    from sphinx.testing.path import path

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================== 36 passed, 1 skipped, 1 warning in 1.67s =====================================================================
nox > Session test was successful.
```

This was introduced by the recent changes, so I don't think it is an urgent one.

ref. Changelog — Sphinx documentation - https://www.sphinx-doc.org/en/master/changes.html#release-7-2-0-released-aug-17-2023