### PR TITLE
Make matplotlib a optional requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Sphinx extension to generate [Open Graph metadata](https://ogp.me/) for each pag
 python -m pip install sphinxext-opengraph
 ```
 
+If you want social media cards
+```sh
+python -m pip install sphinxext-opengraph[social_cards]
+```
+
 ## Usage
 Just add `sphinxext.opengraph` to your extensions list in your `conf.py`
 

--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,7 @@ setuptools.setup(
         "Topic :: Utilities",
     ],
     python_requires=">=3.8",
+    extras_require = {
+        'social_cards':  ["matplotlib"]
+    }
 )


### PR DESCRIPTION
This makes it easier to install. Currently matplotlib is nowhere mentioned, so you only know that you need it by reading the Sphinx Log.