### PR TITLE
Test Sphinx 7

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['pypy3.9', '3.8', '3.9', '3.10', '3.11']
-        sphinx-version: ['>=4,<5', '>=5,<6', '>=6a0,<7']
+        sphinx-version: ['>=4,<5', '>=5,<6', '>=6a0,<7', '>=7,<8']
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Sphinx 7.0.0 was released on 2023-04-30 and we're now up to 7.2.6.

Let's test it.

However, combined with PR #113, that means we have 6 Python versions x 5 Sphinx versions x 3 operating systems = 90 jobs in the matrix!

I suggest we drop support for Sphinx 4 to bring it down to 6x4x3 = 72 jobs.

Alternatively, we could run the full matrix for Ubuntu, but selectively run a subset of versions for other operating systems. For example, for macOS and Windows, only test the lowest/highest supported Sphinx (4 and 7), and/or Python (3.8 and 3.12).