### PR TITLE
Fix default Roboto font not being found by the matplotlib FontManager

### DIFF
--- a/sphinxext/opengraph/socialcards.py
+++ b/sphinxext/opengraph/socialcards.py
@@ -183,11 +183,11 @@ def create_social_card_objects(
     """Create the Matplotlib objects for the first time."""
     # If no font specified, load the Roboto Flex font as a fallback
     if font is None:
-        path_font = Path(__file__).parent / "_static/Roboto-flex.ttf"
+        path_font = Path(__file__).parent / "_static/Roboto-Flex.ttf"
         roboto_font = matplotlib.font_manager.FontEntry(
-            fname=str(path_font), name="Roboto"
+            fname=str(path_font), name="Roboto Flex"
         )
-        matplotlib.font_manager.fontManager.ttflist.append(roboto_font)
+        matplotlib.font_manager.fontManager.addfont(path_font)
         font = roboto_font.name
 
     # Because Matplotlib doesn't let you specify figures in pixels, only inches


### PR DESCRIPTION
Fixes #115 

requirements.txt:
```
sphinx==7.2.6
sphinxext-opengraph==0.9.0
matplotlib==3.8.2
```
With a default `conf.py` created using `sphinx-quickstart` (minus the comments) and adding the `sphinxext-opengraph` extension:
```
project = 'Test'
copyright = '2023, Test Authors'
author = 'Test Authors'

extensions = [
    "sphinxext.opengraph",
]

templates_path = ['_templates']
exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

html_theme = 'alabaster'
html_static_path = ['_static']
```
Running `make html` now creates a beautiful Social Card:

![summary_index_29209853](https://github.com/wpilibsuite/sphinxext-opengraph/assets/9253928/83b522ae-7eb1-4702-82d4-b292cafd7962)
