### PR TITLE
Add conf.py to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.12"
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,3 +16,4 @@ python:
 sphinx:
   builder: html
   fail_on_warning: true
+  configuration: docs/source/conf.py


### PR DESCRIPTION
Required by https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/