### PR TITLE
Fix read the docs canonical url

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,8 +62,6 @@ intersphinx_mapping = {
 
 # -- Configuration for this theme --------------------------------------------
 
-ogp_site_url = 'https://sphinxext-opengraph.readthedocs.io/en/latest/'
-
 # Configuration for testing but generally we use the defaults
 # Uncomment lines to see their effect.
 ogp_social_cards = {

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -253,15 +253,10 @@ def ambient_site_url() -> str:
     # readthedocs addons sets the READTHEDOCS_CANONICAL_URL variable,
     # or defines the ``html_baseurl`` variable in conf.py
     if rtd_canonical_url := os.getenv('READTHEDOCS_CANONICAL_URL'):
-        parse_result = urlsplit(rtd_canonical_url)
+        return rtd_canonical_url
     else:
         msg = 'ReadTheDocs did not provide a valid canonical URL!'
         raise RuntimeError(msg)
-
-    # Grab root url from canonical url
-    return urlunsplit(
-        (parse_result.scheme, parse_result.netloc, parse_result.path, '', '')
-    )
 
 
 def social_card_for_page(

--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -4,7 +4,7 @@ import os
 import posixpath
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
+from urllib.parse import urljoin, urlparse
 
 from docutils import nodes
 
@@ -254,9 +254,8 @@ def ambient_site_url() -> str:
     # or defines the ``html_baseurl`` variable in conf.py
     if rtd_canonical_url := os.getenv('READTHEDOCS_CANONICAL_URL'):
         return rtd_canonical_url
-    else:
-        msg = 'ReadTheDocs did not provide a valid canonical URL!'
-        raise RuntimeError(msg)
+    msg = 'ReadTheDocs did not provide a valid canonical URL!'
+    raise RuntimeError(msg)
 
 
 def social_card_for_page(


### PR DESCRIPTION
The current logic of grabbing the root from the canonical url is wrong:

[![Screenshot 2025-04-22 at 11 22 10](https://github.com/user-attachments/assets/43299e8e-f05e-46f6-bc6e-a9ffc26d04e1)](https://docs.readthedocs.com/platform/stable/reference/environment-variables.html#envvar-READTHEDOCS_CANONICAL_URL)

You can easily see this if you remove this line from `conf.py`:

https://github.com/sphinx-doc/sphinxext-opengraph/blob/0cd67f51ad1e10dbc2b4d075ac787bf343b95058/docs/conf.py#L65

Then you get something like this:

```html
<meta property="og:url" content="https://sphinxext-opengraph.readthedocs.io/index.html">
<meta property="og:image" content="https://sphinxext-opengraph.readthedocs.io/_images/social_previews/summary_index_c6c9679d.png">
```

Documentation preview: https://sphinxext-opengraph--135.org.readthedocs.build/en/135