### PR TITLE
Read the Docs no longer injects html_baseurl: update test and comment

### DIFF
--- a/sphinxext/opengraph/__init__.py
+++ b/sphinxext/opengraph/__init__.py
@@ -250,8 +250,7 @@ def get_tags(
 
 
 def ambient_site_url() -> str:
-    # readthedocs addons sets the READTHEDOCS_CANONICAL_URL variable,
-    # or defines the ``html_baseurl`` variable in conf.py
+    # readthedocs addons sets the READTHEDOCS_CANONICAL_URL variable
     if rtd_canonical_url := os.getenv('READTHEDOCS_CANONICAL_URL'):
         parse_result = urlsplit(rtd_canonical_url)
     else:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -305,7 +305,7 @@ def test_rtd_override(app: Sphinx, monkeypatch):
 @pytest.mark.sphinx('html', testroot='rtd-default')
 def test_rtd_valid(app: Sphinx, monkeypatch):
     monkeypatch.setenv('READTHEDOCS', 'True')
-    app.config.html_baseurl = 'https://failure.com/en/latest/'
+    monkeypatch.setenv('READTHEDOCS_CANONICAL_URL', 'https://failure.com/en/latest/')
 
     app.build()
     tags = conftest._og_meta_tags(app)


### PR DESCRIPTION
9567171ab5758dbaba35ba5163feb2096b437f2b removed checking `config.html_baseurl`, set previously by Read the Docs.

This PR is changing `test_rtd_valid` test, to use `READTHEDOCS_CANONICAL_URL` environment variable instead of the config.

This fixes the CI.