### PR TITLE
Test Python 3.14 and 3.14t

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
         - "3.12"
         - "3.13"
         - "3.13t"
+        - "3.14"
+        - "3.14t"
         sphinx-version:
         - "6"
         - "7"
@@ -56,6 +58,12 @@ jobs:
         - python: "3.13"
           sphinx-version: "8"
           os: "macos-latest"
+        - python: "3.14"
+          sphinx-version: "8"
+          os: "windows-latest"
+        - python: "3.14"
+          sphinx-version: "8"
+          os: "macos-latest"
 
     steps:
     - uses: actions/checkout@v4
@@ -65,6 +73,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
+        allow-prereleases: true
     - name: Check Python version
       run: python --version --version
     - name: Export UV_PYTHON


### PR DESCRIPTION
The Python 3.14 release candidate is out. 🚀 

The 3.14 release manager (👋 hi, that's me!) [said](https://discuss.python.org/t/python-3-14-release-candidate-1-is-go/99754?u=hugovk):

> ## Call to action
> 
> We **_strongly encourage_** maintainers of third-party Python projects to prepare their projects for 3.14 during this phase, and publish Python 3.14 wheels on PyPI to be ready for the final release of 3.14.0, and to help other projects do their own testing. Any binary wheels built against Python 3.14.0rc1 **_will work_** with future versions of Python 3.14. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).

This adds 3.14 to the CI. The classifier was already added in https://github.com/sphinx-doc/sphinxext-opengraph/pull/143.